### PR TITLE
Fix Next.js build by widening type aliases

### DIFF
--- a/webapp/next.config.mjs
+++ b/webapp/next.config.mjs
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    serverActions: false
-  }
-};
+const nextConfig = {};
 
 export default nextConfig;

--- a/webapp/src/components/NewGameForm.tsx
+++ b/webapp/src/components/NewGameForm.tsx
@@ -14,8 +14,8 @@ export function NewGameForm({ availableTeams, onStart }: Props) {
   const [managerName, setManagerName] = useState('Manager');
   const [selectedTeam, setSelectedTeam] = useState<string>(availableTeams[0] ?? '');
   const [customName, setCustomName] = useState('');
-  const [customCountry, setCustomCountry] = useState(COUNTRIES[0]?.id ?? 'Eng');
-  const [customColor, setCustomColor] = useState(COLORS[0]?.hex ?? '#485C96');
+  const [customCountry, setCustomCountry] = useState<string>(COUNTRIES[0]?.id ?? 'Eng');
+  const [customColor, setCustomColor] = useState<string>(COLORS[0]?.hex ?? '#485C96');
   const [customDivision, setCustomDivision] = useState(1);
   const [customPosition, setCustomPosition] = useState(1);
   const [error, setError] = useState<string | null>(null);

--- a/webapp/src/game/game.ts
+++ b/webapp/src/game/game.ts
@@ -18,6 +18,12 @@ interface ManagerConfig {
   name: string;
 }
 
+type TeamSeed = {
+  name: string;
+  country: string;
+  color: string;
+};
+
 export class Game {
   divisions: Division[];
   humanTeams: TeamEntity[];
@@ -50,7 +56,11 @@ export class Game {
   }
 
   start(humanTeam?: HumanTeamConfig, managerConfig?: ManagerConfig): void {
-    const allTeams = [...DB_TEAMS];
+    const allTeams: TeamSeed[] = Array.from(DB_TEAMS, (team): TeamSeed => ({
+      name: team.name,
+      country: team.country,
+      color: team.color
+    }));
     let humanTeamEntry: HumanTeamConfig | null = humanTeam ?? null;
 
     if (humanTeamEntry && humanTeamEntry.prev_div && humanTeamEntry.prev_pos) {

--- a/webapp/src/game/helpers.ts
+++ b/webapp/src/game/helpers.ts
@@ -80,7 +80,9 @@ export function strToTactic(tactic: string): number[] | 'Top skill' {
   return 'Top skill';
 }
 
-export function trainingToStr(training: number): string {
+export type TrainingDelta = '++' | '+' | '-' | '--' | '';
+
+export function trainingToStr(training: number): TrainingDelta {
   if (training >= 0.03) {
     return '++';
   }
@@ -104,7 +106,7 @@ export function randomInt(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-export function randomChoice<T>(items: T[]): T {
+export function randomChoice<T>(items: readonly T[]): T {
   return items[Math.floor(Math.random() * items.length)];
 }
 

--- a/webapp/src/game/player.ts
+++ b/webapp/src/game/player.ts
@@ -18,6 +18,13 @@ export interface PlayerLeagueStats {
   Goals: number;
 }
 
+const TRAINING_NEWS_MAP: Record<Exclude<ReturnType<typeof trainingToStr>, ''>, News['category']> = {
+  '++': 'Training ++',
+  '+': 'Training +',
+  '-': 'Training -',
+  '--': 'Training --'
+};
+
 export class Player {
   skill: number;
   team: Team | null;
@@ -206,8 +213,10 @@ export class Player {
       return [decrease, training];
     }
 
-    if (trainingToStr(training) !== '' && this.team) {
-      this.team.weeklyNews.news.push(new News(`Training ${trainingToStr(training)}`, this.name));
+    const trainingLabel = trainingToStr(training);
+    if (trainingLabel !== '' && this.team) {
+      const category = TRAINING_NEWS_MAP[trainingLabel];
+      this.team.weeklyNews.news.push(new News(category, this.name));
     }
 
     return [0, training];
@@ -249,8 +258,8 @@ export class Player {
   setRenewContractWantedSalary(asking = false): void {
     if (!this.wantedSalary) {
       const base = Math.max(this.salary, this.salaryForSkill());
-      let minIncrease = PLAYER['MIN_SALARY_INCREASE_NOT_ASKING'];
-      let maxIncrease = PLAYER['MAX_SALARY_INCREASE_NOT_ASKING'];
+      let minIncrease: number = PLAYER['MIN_SALARY_INCREASE_NOT_ASKING'];
+      let maxIncrease: number = PLAYER['MAX_SALARY_INCREASE_NOT_ASKING'];
       if (asking) {
         minIncrease = PLAYER['MIN_SALARY_INCREASE'];
         maxIncrease = PLAYER['MAX_SALARY_INCREASE'];

--- a/webapp/src/game/team.ts
+++ b/webapp/src/game/team.ts
@@ -64,7 +64,9 @@ export class Team {
     this.manager = options.manager ?? null;
     this.division = options.division ?? null;
     this.tactic =
-      options.tactic ?? randomChoice([...TEAM['BASE TACTICS'], ...TEAM['DEF TACTICS'], ...TEAM['ATK TACTICS']]);
+      options.tactic ?? [
+        ...randomChoice([...TEAM['BASE TACTICS'], ...TEAM['DEF TACTICS'], ...TEAM['ATK TACTICS']])
+      ];
     this.avgSkill = options.avgSkill ?? TEAM['MIN_SKILL'];
     this.players = options.players ?? [];
     this.human = options.human ?? false;
@@ -541,12 +543,14 @@ export class Team {
     removeRetiredPlayers();
 
     if (!this.human) {
-      this.tactic = randomChoice([
-        ...TEAM['BASE TACTICS'],
-        ...TEAM['BASE TACTICS'],
-        ...TEAM['DEF TACTICS'],
-        ...TEAM['ATK TACTICS']
-      ]);
+      this.tactic = [
+        ...randomChoice([
+          ...TEAM['BASE TACTICS'],
+          ...TEAM['BASE TACTICS'],
+          ...TEAM['DEF TACTICS'],
+          ...TEAM['ATK TACTICS']
+        ])
+      ];
     } else {
       this.players.forEach((player) => player.startOfSeason());
       const amount = Math.round(
@@ -658,7 +662,11 @@ export class Team {
   }
 
   listOfAllowedTactics(): number[][] {
-    const allTactics = [...TEAM['ATK TACTICS'], ...TEAM['BASE TACTICS'], ...TEAM['DEF TACTICS']];
+    const allTactics = [
+      ...TEAM['ATK TACTICS'],
+      ...TEAM['BASE TACTICS'],
+      ...TEAM['DEF TACTICS']
+    ].map((tactic) => [...tactic]);
     return allTactics.filter((tactic) => this.allowedTactic(tactic));
   }
 

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -19,6 +19,9 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
+      "@/game": [
+        "src/game"
+      ],
       "@/game/*": [
         "src/game/*"
       ],


### PR DESCRIPTION
## Summary
- remove deprecated experimental serverActions flag and add a direct `@/game` alias so Next.js can resolve re-exports during production builds
- widen literal-only game data to mutable types by cloning constants, allowing custom teams and utility helpers to work with readonly arrays
- tighten component and helper typings to accept readonly inputs and map training labels to valid news categories

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfca52949483308b248a0a2c2fead0