### PR TITLE
Add full squad management and match parity features

### DIFF
--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -14,11 +14,27 @@ export default function HomePage() {
     playCurrentMatch,
     advanceWeekWithoutMatch,
     currentMatch,
-    rosterByPosition,
     leagueTable,
     selectedTab,
     setSelectedTab,
-    weekNews
+    weekNews,
+    allowedTactics,
+    currentTactic,
+    setHumanTactic,
+    swapPlayerStatuses,
+    liveMatch,
+    isMatchLive,
+    matchTimeline,
+    autoPlaying,
+    startLiveMatch,
+    playLiveMinute,
+    toggleAutoPlay,
+    finishLiveMatch,
+    makeMatchSubstitution,
+    refreshTransferTargets,
+    buyPlayer,
+    sellPlayer,
+    renewContract
   } = useGameEngine();
 
   return (
@@ -49,13 +65,29 @@ export default function HomePage() {
           game={game}
           humanTeam={humanTeam}
           currentMatch={currentMatch}
-          rosterByPosition={rosterByPosition}
           leagueTable={leagueTable}
           weekNews={weekNews}
           selectedTab={selectedTab}
           setSelectedTab={setSelectedTab}
           onPlayMatch={playCurrentMatch}
           onSimulateWeek={advanceWeekWithoutMatch}
+          allowedTactics={allowedTactics}
+          currentTactic={currentTactic}
+          onSetTactic={setHumanTactic}
+          onSwapPlayers={swapPlayerStatuses}
+          liveMatch={liveMatch}
+          isMatchLive={isMatchLive}
+          matchTimeline={matchTimeline}
+          autoPlaying={autoPlaying}
+          onStartLiveMatch={startLiveMatch}
+          onPlayMinute={playLiveMinute}
+          onToggleAutoPlay={toggleAutoPlay}
+          onFinishLiveMatch={finishLiveMatch}
+          onMakeSubstitution={makeMatchSubstitution}
+          onRefreshTransferList={refreshTransferTargets}
+          onBuyPlayer={buyPlayer}
+          onSellPlayer={sellPlayer}
+          onRenewContract={renewContract}
         />
       )}
 

--- a/webapp/src/components/GameDashboard.tsx
+++ b/webapp/src/components/GameDashboard.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { Fragment } from 'react';
-import type { Game, Match, Team, Player } from '@/game';
-import type { TabKey } from '@/hooks/useGameEngine';
+import { useMemo, useState } from 'react';
+import type { Game, Match, Player, Team } from '@/game';
+import type { MatchEvent, OperationResult, TabKey } from '@/hooks/useGameEngine';
+import { SquadBoard } from './SquadBoard';
+import { MatchCenter } from './MatchCenter';
+import { TransferHub } from './TransferHub';
+import { TrainingPanel } from './TrainingPanel';
 
 interface Props {
   game: Game;
   humanTeam: Team;
   currentMatch: Match | null;
-  rosterByPosition: Array<{ label: string; players: Player[] }>;
+  weekNews: string[];
   leagueTable: Array<{
     position: number;
     name: string;
@@ -19,16 +23,34 @@ interface Props {
     goalsFor: number;
     goalsAgainst: number;
   }>;
-  weekNews: string[];
   selectedTab: TabKey;
   setSelectedTab: (tab: TabKey) => void;
   onPlayMatch: () => void;
   onSimulateWeek: () => void;
+  allowedTactics: number[][];
+  currentTactic: number[];
+  onSetTactic: (tactic: number[]) => OperationResult;
+  onSwapPlayers: (playerA: Player, playerB: Player) => OperationResult;
+  liveMatch: Match | null;
+  isMatchLive: boolean;
+  matchTimeline: MatchEvent[];
+  autoPlaying: boolean;
+  onStartLiveMatch: () => OperationResult;
+  onPlayMinute: () => OperationResult;
+  onToggleAutoPlay: () => OperationResult;
+  onFinishLiveMatch: () => OperationResult;
+  onMakeSubstitution: (playerOut: Player, playerIn: Player) => OperationResult;
+  onRefreshTransferList: () => OperationResult;
+  onBuyPlayer: (player: Player) => OperationResult;
+  onSellPlayer: (player: Player) => OperationResult;
+  onRenewContract: (player: Player) => OperationResult;
 }
 
 const tabs: Array<{ key: TabKey; label: string }> = [
   { key: 'team', label: 'Squad' },
   { key: 'match', label: 'Matchday' },
+  { key: 'transfers', label: 'Transfers' },
+  { key: 'training', label: 'Training' },
   { key: 'league', label: 'League' },
   { key: 'finance', label: 'Finances' },
   { key: 'news', label: 'Weekly news' }
@@ -38,28 +60,57 @@ export function GameDashboard({
   game,
   humanTeam,
   currentMatch,
-  rosterByPosition,
-  leagueTable,
   weekNews,
+  leagueTable,
   selectedTab,
   setSelectedTab,
   onPlayMatch,
-  onSimulateWeek
+  onSimulateWeek,
+  allowedTactics,
+  currentTactic,
+  onSetTactic,
+  onSwapPlayers,
+  liveMatch,
+  isMatchLive,
+  matchTimeline,
+  autoPlaying,
+  onStartLiveMatch,
+  onPlayMinute,
+  onToggleAutoPlay,
+  onFinishLiveMatch,
+  onMakeSubstitution,
+  onRefreshTransferList,
+  onBuyPlayer,
+  onSellPlayer,
+  onRenewContract
 }: Props) {
-  const nextMatch = humanTeam.nextMatch(game.week);
-  const nextOpponent = nextMatch ? humanTeam.nextOpponent(game.week) : null;
-  const seasonHeader = `Season ${game.season + 1} · Week ${game.week + 1}`;
+  const [feedback, setFeedback] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
 
-  const headerGradient = `linear-gradient(135deg, rgba(245,216,103,0.15), rgba(255,255,255,0.05))`;
+  const nextOpponent = useMemo(() => humanTeam.nextOpponent(game.week), [humanTeam, game.week]);
+
+  const showFeedback = (result: OperationResult | string, type: 'success' | 'error' | 'info' = 'info') => {
+    if (typeof result === 'string') {
+      setFeedback({ message: result, type });
+    } else {
+      setFeedback({ message: result.message, type: result.success ? 'success' : 'error' });
+    }
+  };
+
+  const handleQuickMatch = () => {
+    onPlayMatch();
+    showFeedback('Played the upcoming fixture using quick simulation. Check the news tab for details.');
+  };
+
+  const handleSimulateWeek = () => {
+    onSimulateWeek();
+    showFeedback('Advanced the season by one week.');
+  };
 
   return (
     <section className="flex w-full max-w-5xl flex-col gap-6">
       <header className="card-surface flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-4">
-          <div
-            className="h-16 w-16 rounded-2xl border border-white/20"
-            style={{ background: headerGradient }}
-          >
+          <div className="h-16 w-16 rounded-2xl border border-white/20" style={{ background: 'linear-gradient(135deg, rgba(245,216,103,0.15), rgba(255,255,255,0.05))' }}>
             <div
               className="h-full w-full rounded-2xl"
               style={{
@@ -70,33 +121,30 @@ export function GameDashboard({
           <div>
             <h1 className="text-2xl font-semibold text-white sm:text-3xl">{humanTeam.name}</h1>
             <p className="text-sm text-subtle">
-              {seasonHeader} · {humanTeam.division?.name ?? 'Friendly league'}
+              Season {game.season + 1} · Week {game.week + 1} · {humanTeam.division?.name ?? 'Friendly league'}
             </p>
             <p className="text-xs text-subtle">
               Fans morale: {Math.round(humanTeam.fanHappiness)} · Balance: €{humanTeam.money.toLocaleString()}
             </p>
+            <p className="text-xs text-subtle">
+              Next opponent: {nextOpponent ? nextOpponent.name : 'Season complete'}
+            </p>
           </div>
         </div>
         <div className="flex flex-col gap-2 sm:text-right">
-          <span className="text-xs uppercase tracking-wide text-subtle">Next opponent</span>
-          {nextOpponent ? (
-            <div className="text-lg font-semibold text-accent">{nextOpponent.name}</div>
-          ) : (
-            <div className="text-lg font-semibold text-accent">Season complete</div>
-          )}
-          <div className="flex gap-2">
+          <span className="text-xs uppercase tracking-wide text-subtle">Fast actions</span>
+          <div className="flex flex-wrap gap-2">
             <button
-              onClick={onPlayMatch}
-              disabled={!nextMatch}
-              className="rounded-full bg-accent/90 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-midnight transition hover:bg-accent disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
+              onClick={handleQuickMatch}
+              className="rounded-full bg-accent/90 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-midnight transition hover:bg-accent"
             >
-              Play week
+              Quick play week
             </button>
             <button
-              onClick={onSimulateWeek}
+              onClick={handleSimulateWeek}
               className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent"
             >
-              Quick sim
+              Simulate all
             </button>
           </div>
         </div>
@@ -116,101 +164,64 @@ export function GameDashboard({
         ))}
       </nav>
 
+      {feedback && (
+        <div
+          className={`rounded-2xl border px-4 py-3 text-sm ${
+            feedback.type === 'success'
+              ? 'border-emerald-400/30 bg-emerald-500/10 text-emerald-200'
+              : feedback.type === 'error'
+              ? 'border-red-400/30 bg-red-500/10 text-red-200'
+              : 'border-white/20 bg-white/5 text-subtle'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
       <div className="card-surface min-h-[320px] p-6">
         {selectedTab === 'team' && (
-          <div className="space-y-4">
-            {rosterByPosition.map(({ label, players }) => (
-              <div key={label} className="space-y-2">
-                <div className="flex items-center justify-between text-sm font-semibold text-accent">
-                  <span>{label}</span>
-                  <span>{players.length} players</span>
-                </div>
-                <div className="overflow-hidden rounded-2xl border border-white/10">
-                  <table className="min-w-full divide-y divide-white/10 text-sm">
-                    <thead className="bg-white/5 text-xs uppercase text-subtle">
-                      <tr>
-                        <th className="px-3 py-2 text-left">Name</th>
-                        <th className="px-3 py-2 text-left">Skill</th>
-                        <th className="px-3 py-2 text-left">Age</th>
-                        <th className="px-3 py-2 text-left">Status</th>
-                        <th className="px-3 py-2 text-left">Wage</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-white/5">
-                      {players.map((player) => (
-                        <tr key={`${player.name}-${player.age}`} className="hover:bg-white/5">
-                          <td className="px-3 py-2 text-white">{player.name}</td>
-                          <td className="px-3 py-2 text-accent">{player.skill.toFixed(1)}</td>
-                          <td className="px-3 py-2 text-subtle">{player.age}</td>
-                          <td className="px-3 py-2 text-subtle">
-                            {player.playingStatus === 0 ? 'Starting XI' : player.playingStatus === 1 ? 'Bench' : 'Reserve'}
-                            {player.injured() ? ' · Injured' : ''}
-                          </td>
-                          <td className="px-3 py-2 text-subtle">€{player.salary.toLocaleString()}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            ))}
-          </div>
+          <SquadBoard
+            team={humanTeam}
+            allowedTactics={allowedTactics}
+            currentTactic={currentTactic}
+            onSetTactic={onSetTactic}
+            onSwapPlayers={onSwapPlayers}
+            onFeedback={showFeedback}
+          />
         )}
 
         {selectedTab === 'match' && (
-          <div className="space-y-4">
-            {currentMatch ? (
-              <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-                <div className="flex flex-col items-center gap-2 text-center">
-                  <span className="text-xs uppercase tracking-wide text-subtle">Final score</span>
-                  <div className="flex items-center gap-4 text-3xl font-semibold text-white">
-                    <span>{currentMatch.teams[0].name}</span>
-                    <span className="rounded-full bg-accent/80 px-4 py-1 text-midnight">
-                      {currentMatch.score[0]} - {currentMatch.score[1]}
-                    </span>
-                    <span>{currentMatch.teams[1].name}</span>
-                  </div>
-                  <p className="text-xs text-subtle">
-                    Possession: {currentMatch.ballPossession()[0]}% · Shots: {currentMatch.goalscorers.length}
-                  </p>
-                </div>
-                <div className="mt-4 space-y-2">
-                  {currentMatch.goalscorers.map((goal, index) => (
-                    <div key={`${goal.player.name}-${index}`} className="flex items-center justify-between rounded-xl bg-white/5 px-4 py-2 text-sm text-white/80">
-                      <span>{goal.minute}&#39; · {goal.team.name}</span>
-                      <span>{goal.player.name}</span>
-                    </div>
-                  ))}
-                  {currentMatch.goalscorers.length === 0 && (
-                    <p className="text-center text-sm text-subtle">No goals scored this week.</p>
-                  )}
-                </div>
-              </div>
-            ) : (
-              <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-center text-subtle">
-                <p className="text-sm">No match played yet. Use “Play week” to simulate the upcoming fixture.</p>
-              </div>
-            )}
-            {nextMatch && (
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-left text-sm text-subtle">
-                  <div className="text-xs uppercase tracking-wide">Match preview</div>
-                  <div className="mt-2 text-lg font-semibold text-white">{humanTeam.name} vs {nextOpponent?.name}</div>
-                  <p className="mt-2">Home advantage: {nextMatch.teams[0] === humanTeam ? 'Yes' : 'No'}</p>
-                  <p>Suggested tactic: {humanTeam.currentTactic().join('-')}</p>
-                </div>
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-subtle">
-                  <div className="text-xs uppercase tracking-wide">Weekly objectives</div>
-                  <ul className="mt-2 space-y-1">
-                    <li>Maintain fan happiness above 50</li>
-                    <li>Keep wages under €{humanTeam.financesWeeklyExpense().toLocaleString()}</li>
-                    <li>Scout transfer list for upgrades</li>
-                  </ul>
-                </div>
-              </div>
-            )}
-          </div>
+          <MatchCenter
+            game={game}
+            team={humanTeam}
+            liveMatch={liveMatch}
+            lastMatch={currentMatch}
+            isMatchLive={isMatchLive}
+            autoPlaying={autoPlaying}
+            timeline={matchTimeline}
+            onStartLiveMatch={onStartLiveMatch}
+            onPlayMinute={onPlayMinute}
+            onToggleAutoPlay={onToggleAutoPlay}
+            onFinishLiveMatch={onFinishLiveMatch}
+            onMakeSubstitution={onMakeSubstitution}
+            onQuickMatch={handleQuickMatch}
+            onQuickWeek={handleSimulateWeek}
+            onFeedback={showFeedback}
+          />
         )}
+
+        {selectedTab === 'transfers' && (
+          <TransferHub
+            team={humanTeam}
+            onRefresh={onRefreshTransferList}
+            onBuy={onBuyPlayer}
+            onSell={onSellPlayer}
+            onRenew={onRenewContract}
+            onFeedback={showFeedback}
+          />
+        )}
+
+        {selectedTab === 'training' && <TrainingPanel team={humanTeam} />}
 
         {selectedTab === 'league' && (
           <div className="overflow-hidden rounded-2xl border border-white/10">
@@ -256,9 +267,7 @@ export function GameDashboard({
                 {Object.entries(humanTeam.weeklyFinances).map(([key, value]) => (
                   <li key={key} className="flex justify-between">
                     <span>{key}</span>
-                    <span className={value >= 0 ? 'text-emerald-300' : 'text-red-300'}>
-                      €{value.toLocaleString()}
-                    </span>
+                    <span className={value >= 0 ? 'text-emerald-300' : 'text-red-300'}>€{value.toLocaleString()}</span>
                   </li>
                 ))}
               </ul>
@@ -269,9 +278,7 @@ export function GameDashboard({
                 {Object.entries(humanTeam.yearlyFinances).map(([key, value]) => (
                   <li key={key} className="flex justify-between">
                     <span>{key}</span>
-                    <span className={value >= 0 ? 'text-emerald-300' : 'text-red-300'}>
-                      €{value.toLocaleString()}
-                    </span>
+                    <span className={value >= 0 ? 'text-emerald-300' : 'text-red-300'}>€{value.toLocaleString()}</span>
                   </li>
                 ))}
               </ul>
@@ -299,7 +306,7 @@ export function GameDashboard({
               <h3 className="text-sm font-semibold text-accent">Long term outlook</h3>
               <p className="mt-2">
                 Keep your supporters engaged by averaging at least {humanTeam.seasonPointsPerWeek.toFixed(2)} points per week.
-                Avoid slipping below position {humanTeam.minPosPerSeasonPointsPerWeek()} to stay aligned with the board&#39;s plan.
+                Avoid slipping below position {humanTeam.minPosPerSeasonPointsPerWeek()} to stay aligned with the board's plan.
               </p>
             </div>
           </div>

--- a/webapp/src/components/MatchCenter.tsx
+++ b/webapp/src/components/MatchCenter.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { Game, Match, Player, Team } from '@/game';
+import type { MatchEvent, OperationResult } from '@/hooks/useGameEngine';
+
+interface MatchCenterProps {
+  game: Game;
+  team: Team;
+  liveMatch: Match | null;
+  lastMatch: Match | null;
+  isMatchLive: boolean;
+  autoPlaying: boolean;
+  timeline: MatchEvent[];
+  onStartLiveMatch: () => OperationResult;
+  onPlayMinute: () => OperationResult;
+  onToggleAutoPlay: () => OperationResult;
+  onFinishLiveMatch: () => OperationResult;
+  onMakeSubstitution: (playerOut: Player, playerIn: Player) => OperationResult;
+  onQuickMatch: () => void;
+  onQuickWeek: () => void;
+  onFeedback: (result: OperationResult) => void;
+}
+
+function formatScore(match: Match | null, club: Team): string {
+  if (!match) {
+    return '—';
+  }
+  const [home, away] = match.score;
+  const homeClub = match.teams[0];
+  return homeClub === club ? `${home} - ${away}` : `${away} - ${home}`;
+}
+
+export function MatchCenter({
+  game,
+  team,
+  liveMatch,
+  lastMatch,
+  isMatchLive,
+  autoPlaying,
+  timeline,
+  onStartLiveMatch,
+  onPlayMinute,
+  onToggleAutoPlay,
+  onFinishLiveMatch,
+  onMakeSubstitution,
+  onQuickMatch,
+  onQuickWeek,
+  onFeedback
+}: MatchCenterProps) {
+  const [subOut, setSubOut] = useState<Player | null>(null);
+  const [subIn, setSubIn] = useState<Player | null>(null);
+
+  const nextMatch = useMemo(() => team.nextMatch(game.week), [team, game.week]);
+  const nextOpponent = useMemo(() => team.nextOpponent(game.week), [team, game.week]);
+
+  const matchInProgress = liveMatch && !liveMatch.finished;
+
+  const possession = liveMatch ? liveMatch.ballPossession() : [50, 50];
+
+  const starters = team.players
+    .filter((player) => player.playingStatus === 0)
+    .sort((a, b) => b.skill - a.skill);
+  const bench = team.players
+    .filter((player) => player.playingStatus === 1)
+    .sort((a, b) => b.skill - a.skill);
+
+  const handleStart = () => {
+    onFeedback(onStartLiveMatch());
+  };
+
+  const handlePlayMinute = () => {
+    onFeedback(onPlayMinute());
+  };
+
+  const handleToggleAutoPlay = () => {
+    onFeedback(onToggleAutoPlay());
+  };
+
+  const handleFinishWeek = () => {
+    onFeedback(onFinishLiveMatch());
+    setSubIn(null);
+    setSubOut(null);
+  };
+
+  const commitSubstitution = (playerOut: Player, playerIn: Player) => {
+    const result = onMakeSubstitution(playerOut, playerIn);
+    onFeedback(result);
+    if (result.success) {
+      setSubIn(null);
+      setSubOut(null);
+    }
+  };
+
+  const handleSubOutSelect = (player: Player) => {
+    if (subOut === player) {
+      setSubOut(null);
+      return;
+    }
+    setSubOut(player);
+    if (subIn) {
+      commitSubstitution(player, subIn);
+    }
+  };
+
+  const handleSubInSelect = (player: Player) => {
+    if (subIn === player) {
+      setSubIn(null);
+      return;
+    }
+    setSubIn(player);
+    if (subOut) {
+      commitSubstitution(subOut, player);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-subtle">Match centre</h3>
+              <p className="text-lg font-semibold text-white">
+                {liveMatch ? `Minute ${liveMatch.minutes}` : `Season ${game.season + 1} · Week ${game.week + 1}`}
+              </p>
+              <p className="text-xs text-subtle">
+                {nextOpponent ? `Next opponent: ${nextOpponent.name}` : 'Season complete'}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={handleStart}
+                disabled={!nextMatch || (liveMatch && !liveMatch.finished)}
+                className="rounded-full bg-accent/90 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-midnight transition disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
+              >
+                Start live match
+              </button>
+              <button
+                onClick={onQuickMatch}
+                className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent"
+              >
+                Quick play week
+              </button>
+              <button
+                onClick={onQuickWeek}
+                className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent"
+              >
+                Simulate all
+              </button>
+            </div>
+          </div>
+
+          {liveMatch && (
+            <div className="mt-4 space-y-3">
+              <div className="rounded-2xl border border-white/10 bg-midnight/40 p-4 text-center text-white">
+                <div className="text-xs uppercase tracking-wide text-subtle">Scoreline</div>
+                <div className="mt-2 text-3xl font-semibold">
+                  {liveMatch.teams[0].name} {liveMatch.score[0]} - {liveMatch.score[1]} {liveMatch.teams[1].name}
+                </div>
+                <div className="mt-2 text-xs text-subtle">
+                  Possession: {possession[0]}% · Shots: {liveMatch.goalscorers.length}
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={handlePlayMinute}
+                  disabled={!matchInProgress}
+                  className="rounded-full bg-accent/80 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-midnight transition disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/40"
+                >
+                  Play minute
+                </button>
+                <button
+                  onClick={handleToggleAutoPlay}
+                  disabled={!matchInProgress && !autoPlaying}
+                  className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+                >
+                  {autoPlaying ? 'Pause auto-play' : 'Auto-play'}
+                </button>
+                <button
+                  onClick={handleFinishWeek}
+                  disabled={!liveMatch.finished}
+                  className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+                >
+                  Finish week
+                </button>
+              </div>
+
+              <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-3 sm:grid-cols-2">
+                <div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-subtle">Starters</div>
+                  <div className="mt-2 flex flex-col gap-2">
+                    {starters.map((player) => (
+                      <button
+                        key={`starter-${player.name}-${player.age}`}
+                        onClick={() => handleSubOutSelect(player)}
+                        className={`rounded-xl border px-3 py-2 text-left text-xs transition ${
+                          subOut === player
+                            ? 'border-accent bg-accent/20 text-white'
+                            : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                        }`}
+                      >
+                        {player.name} · {player.posToStr()} · {player.skill.toFixed(1)}
+                      </button>
+                    ))}
+                    {starters.length === 0 && <p className="text-xs text-subtle">No active starters.</p>}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-subtle">Bench</div>
+                  <div className="mt-2 flex flex-col gap-2">
+                    {bench.map((player) => (
+                      <button
+                        key={`bench-${player.name}-${player.age}`}
+                        onClick={() => handleSubInSelect(player)}
+                        className={`rounded-xl border px-3 py-2 text-left text-xs transition ${
+                          subIn === player
+                            ? 'border-accent bg-accent/20 text-white'
+                            : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                        }`}
+                      >
+                        {player.name} · {player.posToStr()} · {player.skill.toFixed(1)}
+                      </button>
+                    ))}
+                    {bench.length === 0 && <p className="text-xs text-subtle">Bench empty.</p>}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+            <h3 className="text-sm font-semibold text-accent">Latest fixture</h3>
+            <p className="mt-2 text-sm text-subtle">
+              {lastMatch
+                ? `${lastMatch.teams[0].name} vs ${lastMatch.teams[1].name} · ${formatScore(lastMatch, team)}`
+                : 'No matches played yet.'}
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+            <h3 className="text-sm font-semibold text-accent">Timeline</h3>
+            <div className="mt-2 space-y-2 text-xs text-subtle">
+              {timeline.length === 0 && <p>No notable events yet.</p>}
+              {timeline.map((event, index) => (
+                <div key={`${event.type}-${event.minute}-${index}`} className="rounded-xl bg-white/5 px-3 py-2 text-white/80">
+                  <span className="font-semibold text-accent">{event.minute}' · {event.team}</span> — {event.description}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/SquadBoard.tsx
+++ b/webapp/src/components/SquadBoard.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { Player, Team } from '@/game';
+import type { OperationResult } from '@/hooks/useGameEngine';
+
+interface SquadBoardProps {
+  team: Team;
+  allowedTactics: number[][];
+  currentTactic: number[];
+  onSetTactic: (tactic: number[]) => OperationResult;
+  onSwapPlayers: (playerA: Player, playerB: Player) => OperationResult;
+  onFeedback: (result: OperationResult) => void;
+}
+
+const STATUS_CONFIG: Array<{ label: string; status: number; description: string }> = [
+  { label: 'Starting XI', status: 0, description: 'Players on the pitch.' },
+  { label: 'Bench', status: 1, description: 'Available substitutes.' },
+  { label: 'Reserves', status: 2, description: 'Outside the matchday squad.' }
+];
+
+function tacticLabel(tactic: number[]): string {
+  return tactic.join('-');
+}
+
+function positionLabel(position: number): string {
+  if (position === 0) return 'GK';
+  if (position === 1) return 'DF';
+  if (position === 2) return 'MF';
+  return 'FW';
+}
+
+export function SquadBoard({
+  team,
+  allowedTactics,
+  currentTactic,
+  onSetTactic,
+  onSwapPlayers,
+  onFeedback
+}: SquadBoardProps) {
+  const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
+
+  const tacticOptions = useMemo(() => {
+    const unique = new Map<string, number[]>();
+    allowedTactics.forEach((tactic) => {
+      unique.set(tacticLabel(tactic), tactic);
+    });
+    return Array.from(unique.entries()).map(([label, tactic]) => ({ label, tactic }));
+  }, [allowedTactics]);
+
+  const currentTacticLabel = currentTactic.length > 0 ? tacticLabel(currentTactic) : 'Auto';
+
+  const groupedPlayers = STATUS_CONFIG.map((config) => ({
+    ...config,
+    players: team.players
+      .filter((player) => player.playingStatus === config.status)
+      .slice()
+      .sort((a, b) => b.skill - a.skill)
+  }));
+
+  const handleSelect = (player: Player) => {
+    if (!selectedPlayer) {
+      setSelectedPlayer(player);
+      return;
+    }
+    if (selectedPlayer === player) {
+      setSelectedPlayer(null);
+      return;
+    }
+    const result = onSwapPlayers(selectedPlayer, player);
+    onFeedback(result);
+    setSelectedPlayer(null);
+  };
+
+  const handleTacticClick = (tactic: number[]) => {
+    const result = onSetTactic(tactic);
+    onFeedback(result);
+    setSelectedPlayer(null);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-subtle">Formation</h3>
+          <p className="text-lg font-semibold text-white">Current: {currentTacticLabel}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {tacticOptions.map(({ label, tactic }) => {
+            const active = label === currentTacticLabel;
+            return (
+              <button
+                key={label}
+                onClick={() => handleTacticClick(tactic)}
+                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition ${
+                  active ? 'bg-accent/90 text-midnight' : 'border border-white/20 text-subtle hover:border-accent hover:text-white'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        {groupedPlayers.map((group) => (
+          <div key={group.label} className="rounded-3xl border border-white/10 bg-white/5 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-accent">{group.label}</h3>
+                <p className="text-xs text-subtle">{group.description}</p>
+              </div>
+              <span className="text-xs text-subtle">{group.players.length} players</span>
+            </div>
+            <div className="mt-3 flex flex-col gap-2">
+              {group.players.map((player) => {
+                const isSelected = selectedPlayer === player;
+                const unavailable = !player.matchAvailable();
+                return (
+                  <button
+                    key={`${player.name}-${player.age}-${player.position}`}
+                    onClick={() => handleSelect(player)}
+                    className={`flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-left transition ${
+                      isSelected
+                        ? 'border-accent bg-accent/20 text-white'
+                        : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                    } ${unavailable ? 'opacity-60' : ''}`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="rounded-full bg-midnight/70 px-2 py-1 text-xs font-semibold text-accent">
+                        {positionLabel(player.position)}
+                      </span>
+                      <div>
+                        <p className="text-sm font-semibold text-white">{player.name}</p>
+                        <p className="text-xs text-subtle">
+                          Skill {player.skill.toFixed(1)} · Age {player.age} · Wage €{player.salary.toLocaleString()}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="text-xs text-subtle">
+                      {player.injured() ? 'Injured' : player.matchAvailable() ? 'Available' : 'Unavailable'}
+                    </div>
+                  </button>
+                );
+              })}
+              {group.players.length === 0 && (
+                <p className="rounded-2xl border border-dashed border-white/10 px-3 py-6 text-center text-xs text-subtle">
+                  No players in this group.
+                </p>
+              )}
+            </div>
+            <p className="mt-3 text-[0.7rem] text-subtle">
+              Tap once to select a player, then tap another player to swap their match status.
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/TrainingPanel.tsx
+++ b/webapp/src/components/TrainingPanel.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { Team } from '@/game';
+
+interface TrainingPanelProps {
+  team: Team;
+}
+
+function trainingLabel(value: number): string {
+  if (value > 0.5) return '++';
+  if (value > 0.1) return '+';
+  if (value < -0.5) return '--';
+  if (value < -0.1) return '-';
+  return '·';
+}
+
+export function TrainingPanel({ team }: TrainingPanelProps) {
+  const players = useMemo(
+    () =>
+      team.players
+        .slice()
+        .sort((a, b) => a.position - b.position || b.skill - a.skill),
+    [team.players]
+  );
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-accent">Weekly training report</h3>
+          <p className="text-xs text-subtle">Improvements and regressions based on match minutes.</p>
+        </div>
+        <span className="text-xs text-subtle">{players.length} players</span>
+      </div>
+      <div className="mt-3 overflow-x-auto">
+        <table className="min-w-full divide-y divide-white/10 text-left text-xs text-subtle">
+          <thead className="bg-white/5 uppercase">
+            <tr>
+              <th className="px-3 py-2">Pos</th>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2">Age</th>
+              <th className="px-3 py-2">Skill</th>
+              <th className="px-3 py-2">Training</th>
+              <th className="px-3 py-2">Trend</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10">
+            {players.map((player) => (
+              <tr key={`${player.name}-${player.age}-${player.position}`} className="hover:bg-white/5">
+                <td className="px-3 py-2 text-white">{player.posToStr()}</td>
+                <td className="px-3 py-2 text-white">{player.name}</td>
+                <td className="px-3 py-2">{player.age}</td>
+                <td className="px-3 py-2">{player.skill.toFixed(1)}</td>
+                <td className="px-3 py-2">{player.weeklyTraining.toFixed(2)}</td>
+                <td className="px-3 py-2 text-accent">{trainingLabel(player.weeklyTraining)}</td>
+              </tr>
+            ))}
+            {players.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-6 text-center text-subtle">
+                  No training data recorded this week.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/TransferHub.tsx
+++ b/webapp/src/components/TransferHub.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { Player, Team } from '@/game';
+import type { OperationResult } from '@/hooks/useGameEngine';
+
+interface TransferHubProps {
+  team: Team;
+  onRefresh: () => OperationResult;
+  onBuy: (player: Player) => OperationResult;
+  onSell: (player: Player) => OperationResult;
+  onRenew: (player: Player) => OperationResult;
+  onFeedback: (result: OperationResult) => void;
+}
+
+function formatMoney(value: number): string {
+  return `€${value.toLocaleString()}`;
+}
+
+export function TransferHub({ team, onRefresh, onBuy, onSell, onRenew, onFeedback }: TransferHubProps) {
+  const [selectedTransfer, setSelectedTransfer] = useState<Player | null>(null);
+  const [selectedSquad, setSelectedSquad] = useState<Player | null>(null);
+
+  const transferTargets = useMemo(
+    () => team.playersToBuy.slice().sort((a, b) => b.skill - a.skill || a.currentValue() - b.currentValue()),
+    [team.playersToBuy]
+  );
+
+  const squadPlayers = useMemo(
+    () =>
+      team.players
+        .slice()
+        .sort((a, b) => a.position - b.position || b.skill - a.skill || a.age - b.age),
+    [team.players]
+  );
+
+  const handleRefresh = () => {
+    onFeedback(onRefresh());
+  };
+
+  const handleBuy = (player: Player) => {
+    setSelectedTransfer(player);
+  };
+
+  const handleConfirmBuy = () => {
+    if (!selectedTransfer) {
+      return;
+    }
+    onFeedback(onBuy(selectedTransfer));
+    setSelectedTransfer(null);
+  };
+
+  const handleSell = (player: Player) => {
+    setSelectedSquad(player);
+  };
+
+  const handleConfirmSell = () => {
+    if (!selectedSquad) {
+      return;
+    }
+    onFeedback(onSell(selectedSquad));
+    setSelectedSquad(null);
+  };
+
+  const handleRenew = (player: Player) => {
+    onFeedback(onRenew(player));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-subtle">Transfer war room</h3>
+          <p className="text-xs text-subtle">
+            Budget: {formatMoney(team.money)} · Weekly wages: {formatMoney(team.playersSalarySum())}
+          </p>
+        </div>
+        <button
+          onClick={handleRefresh}
+          className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent"
+        >
+          Refresh transfer list
+        </button>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-semibold text-accent">Available signings</h3>
+              <p className="text-xs text-subtle">Players scouted this week.</p>
+            </div>
+            <span className="text-xs text-subtle">{transferTargets.length}</span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {transferTargets.map((player) => (
+              <button
+                key={`target-${player.name}-${player.age}`}
+                onClick={() => handleBuy(player)}
+                className={`flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-left text-xs transition ${
+                  selectedTransfer === player
+                    ? 'border-accent bg-accent/20 text-white'
+                    : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                }`}
+              >
+                <div>
+                  <p className="text-sm font-semibold text-white">{player.name}</p>
+                  <p className="text-xs text-subtle">
+                    {player.posToStr()} · Skill {player.skill.toFixed(0)} · Wage {formatMoney(player.salary)}
+                  </p>
+                </div>
+                <span className="text-sm font-semibold text-accent">{formatMoney(player.currentValue())}</span>
+              </button>
+            ))}
+            {transferTargets.length === 0 && (
+              <p className="rounded-2xl border border-dashed border-white/10 px-3 py-6 text-center text-xs text-subtle">
+                No players currently listed.
+              </p>
+            )}
+          </div>
+          {selectedTransfer && (
+            <div className="mt-3 rounded-2xl border border-white/10 bg-white/10 p-3 text-xs text-white/80">
+              <p className="font-semibold text-accent">Confirm signing</p>
+              <p className="mt-1">
+                Sign {selectedTransfer.name} for {formatMoney(selectedTransfer.currentValue())}? Their weekly wage demand is
+                {formatMoney(selectedTransfer.salary)}.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  onClick={handleConfirmBuy}
+                  className="rounded-full bg-accent/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-midnight"
+                >
+                  Confirm
+                </button>
+                <button
+                  onClick={() => setSelectedTransfer(null)}
+                  className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/70"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-sm font-semibold text-accent">Your squad</h3>
+              <p className="text-xs text-subtle">Manage contracts and departures.</p>
+            </div>
+            <span className="text-xs text-subtle">{team.players.length}</span>
+          </div>
+          <div className="mt-3 space-y-2">
+            {squadPlayers.map((player) => {
+              const canSell = player.canBeSold();
+              const contractLabel = player.contract > 0 ? `${player.contract} weeks` : 'Expiring';
+              return (
+                <div
+                  key={`squad-${player.name}-${player.age}`}
+                  className={`flex flex-col gap-2 rounded-2xl border px-3 py-2 text-xs transition sm:flex-row sm:items-center sm:justify-between ${
+                    selectedSquad === player
+                      ? 'border-accent bg-accent/20 text-white'
+                      : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                  }`}
+                >
+                  <div>
+                    <p className="text-sm font-semibold text-white">{player.name}</p>
+                    <p className="text-xs text-subtle">
+                      {player.posToStr()} · Skill {player.skill.toFixed(0)} · Value {formatMoney(player.currentValue())}
+                    </p>
+                    <p className="text-xs text-subtle">Contract: {contractLabel}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      onClick={() => handleSell(player)}
+                      disabled={!canSell}
+                      className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/80 transition hover:border-red-400 hover:text-red-200 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+                    >
+                      Sell
+                    </button>
+                    <button
+                      onClick={() => handleRenew(player)}
+                      disabled={player.contract > 0}
+                      className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/80 transition hover:border-emerald-400 hover:text-emerald-200 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+                    >
+                      Renew
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+            {squadPlayers.length === 0 && (
+              <p className="rounded-2xl border border-dashed border-white/10 px-3 py-6 text-center text-xs text-subtle">
+                No registered players.
+              </p>
+            )}
+          </div>
+          {selectedSquad && (
+            <div className="mt-3 rounded-2xl border border-white/10 bg-white/10 p-3 text-xs text-white/80">
+              <p className="font-semibold text-accent">Confirm sale</p>
+              <p className="mt-1">
+                Sell {selectedSquad.name} for {formatMoney(selectedSquad.currentValue())}? This action is final.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  onClick={handleConfirmSell}
+                  className="rounded-full bg-red-500/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white"
+                >
+                  Confirm
+                </button>
+                <button
+                  onClick={() => setSelectedSquad(null)}
+                  className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/70"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/game/game.test.ts
+++ b/webapp/src/game/game.test.ts
@@ -67,4 +67,69 @@ describe('Game engine parity', () => {
     expect(match.minutes).toBe(90);
     expect(humanTeam.leagueStats.Wins + humanTeam.leagueStats.Draws + humanTeam.leagueStats.Losses).toBe(1);
   });
+
+  it('allows setting tactics and swapping players between statuses', () => {
+    const game = new Game('Tactics Test');
+    game.start(
+      {
+        name: SAMPLE_TEAM.name,
+        color: SAMPLE_TEAM.color,
+        country: SAMPLE_TEAM.country
+      },
+      { name: 'Strategist' }
+    );
+    game.startOfSeason();
+    const team = game.humanTeams[0];
+    const allowed = team.listOfAllowedTactics();
+    expect(allowed.length).toBeGreaterThan(0);
+    const tactic = allowed[0];
+    team.setPlayingTactic(tactic);
+    const starters = team.players.filter((player) => player.playingStatus === 0);
+    expect(starters.length).toBe(11);
+
+    const interchangeableStarter = starters.find((player) => player.position !== 0);
+    const reserve = team.players.find(
+      (player) => player.playingStatus === 2 && interchangeableStarter && player.position === interchangeableStarter.position
+    );
+    if (interchangeableStarter && reserve) {
+      const swapped = team.replacePlayer(reserve, interchangeableStarter);
+      expect(swapped).toBe(true);
+      expect(reserve.playingStatus).toBe(0);
+      expect(interchangeableStarter.playingStatus).not.toBe(0);
+    }
+  });
+
+  it('supports buying, renewing and selling players like the original game', () => {
+    const game = new Game('Transfer Test');
+    game.start(
+      {
+        name: SAMPLE_TEAM.name,
+        color: SAMPLE_TEAM.color,
+        country: SAMPLE_TEAM.country
+      },
+      { name: 'Director' }
+    );
+    game.startOfSeason();
+    const team = game.humanTeams[0];
+    team.money = 100_000_000;
+    team.setTransferList();
+    expect(team.playersToBuy.length).toBeGreaterThan(0);
+    const candidate = team.playersToBuy[0];
+    const bought = team.buyPlayer(candidate);
+    expect(bought).toBe(true);
+    expect(team.players.includes(candidate)).toBe(true);
+
+    candidate.contract = 0;
+    candidate.setRenewContractWantedSalary(true);
+    const renewed = team.renewContract(candidate);
+    expect(renewed).toBe(true);
+    expect(candidate.contract).toBe(COMPETITION['TOTAL GAMES']);
+
+    const sellTarget = team.players.find((player) => player !== candidate && player.position !== 0);
+    if (sellTarget) {
+      sellTarget.contract = 0;
+      const sold = team.sellPlayer(sellTarget);
+      expect(sold).toBe(true);
+    }
+  });
 });

--- a/webapp/src/game/team.ts
+++ b/webapp/src/game/team.ts
@@ -285,6 +285,27 @@ export class Team {
     return false;
   }
 
+  buyPlayer(player: Player): boolean {
+    if (!this.hasPlaceToBuyPlayer() || !this.hasMoneyToBuyPlayer(player)) {
+      return false;
+    }
+    this.players.push(player);
+    player.contract = COMPETITION['TOTAL GAMES'];
+    player.playingStatus = 2;
+    player.team = this;
+    this.changeFinances('Bought Players', -player.currentValue());
+    this.playersToBuy = this.playersToBuy.filter((candidate) => candidate !== player);
+    return true;
+  }
+
+  renewContract(player: Player): boolean {
+    if (player.contract > 0) {
+      return false;
+    }
+    player.renewContract();
+    return true;
+  }
+
   hasMoneyToBuyPlayer(player: Player): boolean {
     return player.currentValue() <= this.money;
   }

--- a/webapp/src/hooks/useGameEngine.ts
+++ b/webapp/src/hooks/useGameEngine.ts
@@ -1,9 +1,28 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
-import { COMPETITION, Game, Match, Team, TEAMS } from '@/game';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { COMPETITION, Game, Match, Player, TEAMS } from '@/game';
 
-export type TabKey = 'team' | 'match' | 'league' | 'finance' | 'news';
+export type TabKey =
+  | 'team'
+  | 'match'
+  | 'league'
+  | 'finance'
+  | 'news'
+  | 'transfers'
+  | 'training';
+
+export interface MatchEvent {
+  minute: number;
+  type: 'goal' | 'injury' | 'substitution';
+  team: string;
+  description: string;
+}
+
+export interface OperationResult {
+  success: boolean;
+  message: string;
+}
 
 export interface NewGamePayload {
   gameName: string;
@@ -18,12 +37,39 @@ export interface NewGamePayload {
   } | null;
 }
 
+function formatTactic(tactic: number[]): string {
+  return tactic.join('-');
+}
+
 export function useGameEngine() {
   const gameRef = useRef<Game | null>(null);
-  const [version, setVersion] = useState(0);
+  const liveMatchRef = useRef<Match | null>(null);
+  const autoPlayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const [, setVersion] = useState(0);
   const [currentMatch, setCurrentMatch] = useState<Match | null>(null);
   const [selectedTab, setSelectedTab] = useState<TabKey>('team');
   const [weekNews, setWeekNews] = useState<string[]>([]);
+  const [matchTimeline, setMatchTimeline] = useState<MatchEvent[]>([]);
+  const [isMatchLive, setIsMatchLive] = useState(false);
+  const [autoPlaying, setAutoPlaying] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (autoPlayTimerRef.current) {
+        clearInterval(autoPlayTimerRef.current);
+        autoPlayTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const stopAutoPlay = () => {
+    if (autoPlayTimerRef.current) {
+      clearInterval(autoPlayTimerRef.current);
+      autoPlayTimerRef.current = null;
+    }
+    setAutoPlaying(false);
+  };
 
   const game = gameRef.current;
   const humanTeam = game?.humanTeams[0] ?? null;
@@ -71,6 +117,9 @@ export function useGameEngine() {
     gameInstance.startOfSeason();
 
     gameRef.current = gameInstance;
+    liveMatchRef.current = null;
+    stopAutoPlay();
+    setMatchTimeline([]);
     setVersion((v) => v + 1);
     setCurrentMatch(null);
     setSelectedTab('team');
@@ -79,10 +128,21 @@ export function useGameEngine() {
 
   const resetGame = () => {
     gameRef.current = null;
+    liveMatchRef.current = null;
+    stopAutoPlay();
+    setMatchTimeline([]);
     setVersion((v) => v + 1);
     setCurrentMatch(null);
     setWeekNews([]);
     setSelectedTab('team');
+  };
+
+  const refreshWeeklyState = () => {
+    if (!humanTeam) {
+      return;
+    }
+    humanTeam.setTransferList();
+    setWeekNews(humanTeam.weeklyNews.strList());
   };
 
   const playCurrentMatch = () => {
@@ -95,7 +155,10 @@ export function useGameEngine() {
       return;
     }
 
-    // simulate other matches in the same division first except the human match
+    liveMatchRef.current = null;
+    stopAutoPlay();
+    setMatchTimeline([]);
+
     activeDivision.matches[week]
       .filter((m) => m !== match)
       .forEach((m) => {
@@ -104,17 +167,15 @@ export function useGameEngine() {
         }
       });
 
-    // simulate matches in other divisions
     game.divisions
       .filter((division) => division !== activeDivision)
       .forEach((division) => division.simulateWeeklyMatches(week));
 
-    // play the human match
     match.simulate();
     setCurrentMatch(match);
 
     game.nextWeek();
-    setWeekNews(humanTeam.weeklyNews.strList());
+    refreshWeeklyState();
     setVersion((v) => v + 1);
   };
 
@@ -126,16 +187,257 @@ export function useGameEngine() {
     game.divisions.forEach((division) => division.simulateWeeklyMatches(week));
     game.nextWeek();
     setCurrentMatch(null);
-    setWeekNews(humanTeam.weeklyNews.strList());
+    refreshWeeklyState();
     setVersion((v) => v + 1);
   };
 
-  const rosterByPosition = !humanTeam
-    ? []
-    : ['Goalkeepers', 'Defenders', 'Midfielders', 'Forwards'].map((label, index) => ({
-        label,
-        players: humanTeam.players.filter((player) => player.position === index)
-      }));
+  const setHumanTactic = (tactic: number[]): OperationResult => {
+    if (!humanTeam) {
+      return { success: false, message: 'No active club available.' };
+    }
+    try {
+      humanTeam.setPlayingTactic([...tactic]);
+      humanTeam.orderPlayersByPlayingStatus();
+      setVersion((v) => v + 1);
+      return { success: true, message: `Formation set to ${formatTactic(tactic)}.` };
+    } catch (error) {
+      if (error instanceof Error) {
+        return { success: false, message: error.message };
+      }
+      return { success: false, message: 'Unable to apply the selected tactic.' };
+    }
+  };
+
+  const swapPlayerStatuses = (playerA: Player, playerB: Player): OperationResult => {
+    if (!humanTeam) {
+      return { success: false, message: 'No active club available.' };
+    }
+    if (playerA === playerB) {
+      return { success: true, message: 'No changes made.' };
+    }
+    const swapped =
+      humanTeam.replacePlayer(playerA, playerB) || humanTeam.replacePlayer(playerB, playerA);
+    if (!swapped) {
+      return { success: false, message: 'Swap not allowed for the selected players.' };
+    }
+    humanTeam.orderPlayersByPlayingStatus();
+    setVersion((v) => v + 1);
+    return { success: true, message: 'Players swapped successfully.' };
+  };
+
+  const startLiveMatch = (): OperationResult => {
+    if (!game || !humanTeam) {
+      return { success: false, message: 'No active match available.' };
+    }
+    const week = game.week;
+    const match = humanTeam.nextMatch(week);
+    if (!match) {
+      return { success: false, message: 'There is no scheduled fixture this week.' };
+    }
+    if (match.finished) {
+      return { success: false, message: 'This match has already been completed.' };
+    }
+
+    liveMatchRef.current = match;
+    stopAutoPlay();
+    setMatchTimeline([]);
+    setCurrentMatch(null);
+    setIsMatchLive(true);
+    setVersion((v) => v + 1);
+    return { success: true, message: 'Kick-off! Manage the match minute by minute.' };
+  };
+
+  const playLiveMinute = (): OperationResult => {
+    const match = liveMatchRef.current;
+    if (!match) {
+      return { success: false, message: 'No live match in progress.' };
+    }
+    if (match.finished) {
+      return { success: false, message: 'The match has already finished.' };
+    }
+
+    const previousGoalCount = match.goalscorers.length;
+    const progressed = match.minute();
+    if (!progressed) {
+      return { success: false, message: 'Unable to advance the match.' };
+    }
+
+    const newEvents: MatchEvent[] = [];
+    const latestGoals = match.goalscorers.slice(previousGoalCount);
+    latestGoals.forEach((goal) => {
+      newEvents.push({
+        minute: goal.minute,
+        type: 'goal',
+        team: goal.team.name,
+        description: `${goal.team.name} goal! ${goal.player.name} scores.`
+      });
+    });
+
+    if (match.injuredPlayerOut) {
+      const player = match.injuredPlayerOut;
+      newEvents.push({
+        minute: match.minutes,
+        type: 'injury',
+        team: player.team?.name ?? humanTeam?.name ?? 'Unknown',
+        description: `${player.name} is injured and leaves the pitch.`
+      });
+    }
+
+    if (newEvents.length > 0) {
+      setMatchTimeline((events) => [...events, ...newEvents]);
+    }
+
+    if (match.finished) {
+      stopAutoPlay();
+      setIsMatchLive(false);
+    }
+
+    setVersion((v) => v + 1);
+    return { success: true, message: `Advanced to minute ${match.minutes}.` };
+  };
+
+  const toggleAutoPlay = (): OperationResult => {
+    const match = liveMatchRef.current;
+    if (!match || !isMatchLive) {
+      return { success: false, message: 'Start the live match before enabling auto-play.' };
+    }
+    if (autoPlaying) {
+      stopAutoPlay();
+      return { success: true, message: 'Auto-play paused.' };
+    }
+    autoPlayTimerRef.current = setInterval(() => {
+      const result = playLiveMinute();
+      if (!result.success) {
+        stopAutoPlay();
+      }
+      if (liveMatchRef.current?.finished) {
+        stopAutoPlay();
+      }
+    }, 600);
+    setAutoPlaying(true);
+    return { success: true, message: 'Auto-play engaged.' };
+  };
+
+  const finishLiveMatch = (): OperationResult => {
+    const match = liveMatchRef.current;
+    if (!match) {
+      return { success: false, message: 'No match to conclude.' };
+    }
+    if (!match.finished) {
+      return { success: false, message: 'Play the full 90 minutes before finishing the week.' };
+    }
+    if (!game || !humanTeam) {
+      return { success: false, message: 'No active save to progress.' };
+    }
+
+    stopAutoPlay();
+    game.divisions.forEach((division) => division.simulateWeeklyMatches(game.week));
+    game.nextWeek();
+    setCurrentMatch(match);
+    refreshWeeklyState();
+    liveMatchRef.current = null;
+    setIsMatchLive(false);
+    setVersion((v) => v + 1);
+    return { success: true, message: 'Week completed. Check the latest news and finances.' };
+  };
+
+  const makeMatchSubstitution = (playerOut: Player, playerIn: Player): OperationResult => {
+    const match = liveMatchRef.current;
+    if (!match || !humanTeam) {
+      return { success: false, message: 'No live match in progress.' };
+    }
+    if (!match.allowSubstitution(humanTeam)) {
+      return { success: false, message: 'You have used all available substitutions.' };
+    }
+    const substituted = humanTeam.replacePlayer(playerIn, playerOut, true, match.minutes);
+    if (!substituted) {
+      return { success: false, message: 'The selected substitution is not allowed.' };
+    }
+    match.substitutionMadeByTeam(humanTeam);
+    setMatchTimeline((events) => [
+      ...events,
+      {
+        minute: match.minutes,
+        type: 'substitution',
+        team: humanTeam.name,
+        description: `${playerIn.name} replaces ${playerOut.name}.`
+      }
+    ]);
+    humanTeam.orderPlayersByPlayingStatus();
+    setVersion((v) => v + 1);
+    return { success: true, message: 'Substitution confirmed.' };
+  };
+
+  const refreshTransferTargets = (): OperationResult => {
+    if (!humanTeam) {
+      return { success: false, message: 'No active club available.' };
+    }
+    humanTeam.setTransferList();
+    setVersion((v) => v + 1);
+    return { success: true, message: 'Transfer list refreshed.' };
+  };
+
+  const buyPlayer = (player: Player): OperationResult => {
+    if (!humanTeam) {
+      return { success: false, message: 'No active club available.' };
+    }
+    if (!humanTeam.hasPlaceToBuyPlayer()) {
+      return { success: false, message: 'Squad already has the maximum number of players.' };
+    }
+    if (!humanTeam.hasMoneyToBuyPlayer(player)) {
+      return { success: false, message: 'Not enough funds to complete this transfer.' };
+    }
+    if (!humanTeam.buyPlayer(player)) {
+      return { success: false, message: 'Transfer failed unexpectedly.' };
+    }
+    setVersion((v) => v + 1);
+    return {
+      success: true,
+      message: `${player.name} joins the club for €${player.currentValue().toLocaleString()}.`
+    };
+  };
+
+  const sellPlayer = (player: Player): OperationResult => {
+    if (!humanTeam) {
+      return { success: false, message: 'No active club available.' };
+    }
+    if (!humanTeam.hasPlaceToSellPlayer()) {
+      return { success: false, message: 'You must keep at least eleven players in the squad.' };
+    }
+    if (player.position === 0 && !humanTeam.hasAtLeastOneGk()) {
+      return { success: false, message: 'You need to retain at least one goalkeeper.' };
+    }
+    if (!player.canBeSold()) {
+      return { success: false, message: 'This player cannot be sold right now.' };
+    }
+    if (!humanTeam.sellPlayer(player)) {
+      return { success: false, message: 'Sale failed unexpectedly.' };
+    }
+    setVersion((v) => v + 1);
+    return {
+      success: true,
+      message: `${player.name} sold for €${player.currentValue().toLocaleString()}.`
+    };
+  };
+
+  const renewContract = (player: Player): OperationResult => {
+    if (!humanTeam) {
+      return { success: false, message: 'No active club available.' };
+    }
+    if (player.contract > 0) {
+      return { success: false, message: 'The player already has a valid contract.' };
+    }
+    player.setRenewContractWantedSalary(true);
+    const desiredSalary = player.wantedSalary ?? player.salary;
+    if (!humanTeam.renewContract(player)) {
+      return { success: false, message: 'Contract renewal failed.' };
+    }
+    setVersion((v) => v + 1);
+    return {
+      success: true,
+      message: `${player.name} renewed on €${desiredSalary.toLocaleString()} per week.`
+    };
+  };
 
   const leagueTable = !activeDivision
     ? []
@@ -150,6 +452,10 @@ export function useGameEngine() {
         goalsAgainst: team.leagueStats['Goals Against']
       }));
 
+  const allowedTactics = humanTeam?.listOfAllowedTactics() ?? [];
+  const currentTactic = humanTeam?.currentTactic() ?? [];
+  const liveMatch = liveMatchRef.current;
+
   return {
     game,
     humanTeam,
@@ -159,10 +465,26 @@ export function useGameEngine() {
     playCurrentMatch,
     advanceWeekWithoutMatch,
     currentMatch,
-    rosterByPosition,
     leagueTable,
     selectedTab,
     setSelectedTab,
-    weekNews
+    weekNews,
+    allowedTactics,
+    currentTactic,
+    setHumanTactic,
+    swapPlayerStatuses,
+    liveMatch,
+    isMatchLive,
+    matchTimeline,
+    autoPlaying,
+    startLiveMatch,
+    playLiveMinute,
+    toggleAutoPlay,
+    finishLiveMatch,
+    makeMatchSubstitution,
+    refreshTransferTargets,
+    buyPlayer,
+    sellPlayer,
+    renewContract
   };
 }


### PR DESCRIPTION
## Summary
- implement full-featured squad, match, transfer and training dashboards for the web UI to mirror the original SimpleFM screens
- extend the game engine hook with tactic management, live match controls, transfer actions and operation feedback
- port buy/renew contract helpers and expand parity tests to cover formations and transfer flows

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfd0bd5fd8833089117c5bc31226bd