### PR TITLE
Refine web UI to match Kivy flow and document game systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# SimpleFM Web Tutorial
+
+SimpleFM Web is a faithful browser recreation of the original Kivy prototype for Simple Football Manager. This guide walks you through launching the web client and following the same flow as the desktop version: start a new career, manage your squad, play matches week by week and review the information screens in order.
+
+## Getting started
+
+The web client lives in the [`webapp/`](webapp) folder and uses Next.js 14.
+
+1. Install dependencies:
+
+   ```bash
+   cd webapp
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Open [http://localhost:3000](http://localhost:3000) in your browser. The landing page mirrors the Kivy start screen with *New Game* and *Load Game* options over the classic stadium background.
+
+## Core game flow
+
+The UI intentionally reproduces the original Kivy journey. Move through the screens in this order to experience a full in-game week.
+
+### 1. Start screen
+
+Choose **New Game** to begin a career. (Load Game is reserved for future browser save support, just as the desktop edition loads from the filesystem.)
+
+### 2. New Game screen
+
+You are taken to the familiar form with stacked sections:
+
+- **Game name** and **Manager name** inputs accept up to 16 alphanumeric characters.
+- The **Team** spinner lets you pick an existing club or choose *Create new team* to reveal the custom club section.
+- Custom clubs include fields for name, country, primary colour, starting division and position—matching the layout of the Kivy screen.
+- Use the **Back** button to return to the start menu or **Create Game** to launch the save.
+
+### 3. Main screen layout
+
+After creating a game you land on the main management screen, which keeps the Kivy hierarchy:
+
+1. **Top header** – shows the game name, club, season/week, balance and fan happiness. The *Manager stats* button opens the full career overview overlay, just like pressing the manager icon on desktop.
+2. **Central content area** – holds the active sub-screen. The navigation footer mirrors the original buttons: **Team**, **Training**, **Transfers**, **Information**, **League**.
+3. **Footer** – the white bar with the five navigation buttons. A *Quit to menu* link behaves like returning to the start screen.
+
+### 4. Team screen
+
+- Use the tactic dropdown (Kivy's tactics spinner) to pick a formation. Players are split into the same three groups—Starting XI, Bench and Reserves. Tap a player and then another to swap their match status.
+- The information banner shows the upcoming opponent. Press **Go to match screen** to open the match centre.
+
+### 5. Match screen
+
+The match centre is a modal that recreates the Kivy match controls:
+
+1. **Timeline** on the left displays live events or the final list of scorers.
+2. **Controls** on the right give you *Kick-off*, *Play minute*, *Auto-play* and *Finish match*. Disabled buttons mirror the Kivy gating when a match is not in progress.
+3. **On the pitch** and **Bench** sections let you tap to set up substitutions. Selecting one starter and one substitute triggers the change.
+4. Close the screen to return to the main menu once the match is finished.
+
+### 6. Training screen
+
+Shows the weekly training report with positions, skills and trend arrows. This replaces the *Weekly Training* Kivy view.
+
+### 7. Transfers screen
+
+Lists scouted players on the left and your squad on the right. The flow matches the *Transfer List* screen:
+
+- Tap a target to queue a signing and confirm or cancel.
+- Choose a squad player to sell or renew, observing contract status and wage impact.
+
+### 8. Information screen
+
+Combines the *Finances* and *Weekly Information* screens:
+
+- Weekly and season finances, board expectations and supporter goals.
+- Weekly news items mirror the press messages from the desktop UI.
+- Use **Continue week** to simulate the next week. After a match, the weekly summary modal appears before returning here.
+
+### 9. League screen
+
+Displays the divisional table with the human club highlighted, replicating the Kivy division tables.
+
+Repeat steps 4–8 every week. Each completed week surfaces the summary overlay with match result, training changes, finances and news before you continue.
+
+## Learn more
+
+Detailed documentation about the simulation internals—teams, players, transfers, finances and the match engine—resides in the [`docs/`](docs) directory:
+
+- [`docs/game-structure.md`](docs/game-structure.md) – how the engine organises seasons, divisions and screen flow.
+- [`docs/teams-and-players.md`](docs/teams-and-players.md) – roster management, player attributes and morale.
+- [`docs/matches-and-training.md`](docs/matches-and-training.md) – match simulation, substitutions, training updates and weekly routines.
+- [`docs/transfers-and-finances.md`](docs/transfers-and-finances.md) – transfer market, contracts, finances and board expectations.
+
+Use these references alongside the tutorial to master SimpleFM.

--- a/docs/game-structure.md
+++ b/docs/game-structure.md
@@ -1,0 +1,46 @@
+# Game structure and screen flow
+
+SimpleFM uses a deterministic weekly loop that mirrors the original Kivy application. Understanding how the objects collaborate clarifies why the web UI reproduces the same set of screens and transitions.
+
+## Core entities
+
+- **Game** (`webapp/src/game/game.ts`) orchestrates seasons, divisions and managers. It holds:
+  - `divisions`: ordered list of competitive divisions plus an extra pool for overflow teams.
+  - `humanTeams`: array of human-controlled clubs (the web port keeps one, mirroring the prototype).
+  - `managers`: includes the human manager and AI managers for bookkeeping.
+  - `week` and `season` counters.
+- **Division** pairs fixtures week by week and calculates standings. Each division exposes `matches[week]` to fetch the round currently being played.
+- **Team** encapsulates the club state: tactic, roster, finances, morale and weekly news. Methods such as `nextMatch`, `nextOpponent`, `setTransferList`, `weeklyNews` and `minPosPerSeasonPointsPerWeek` power the UI.
+- **Manager** records yearly statistics (`yearlyStats`) and aggregates career milestones. The *Manager stats* overlay pulls data from `careerStats()` and `careerStatsOrder()`.
+
+## Starting a new game
+
+1. The new game screen collects the same inputs as the Kivy form (game name, manager, team/custom club configuration).
+2. `Game.start` seeds all divisions with the base database, optionally inserting the custom club at the requested division/position.
+3. `Game.createHumanTeam` flags the chosen team as human, builds a full roster based on average division skill, assigns sponsorship and instantiates the `Manager`.
+4. `Game.startOfSeason` schedules fixtures for every division and creates the first season entry for the manager. The UI then renders the **Main screen** with the Team tab active.
+
+## Weekly loop
+
+Each in-game week follows the same order as the Kivy desktop flow:
+
+1. **Squad management** – Adjust tactics and matchday squads on the Team screen. The footer’s *Play* equivalent opens the match centre.
+2. **Match centre** – Kick-off, advance minute by minute or toggle auto-play. When the match ends the engine stores the `Match` instance as `currentMatch`.
+3. **Weekly summary** – `useGameEngine.finalizeWeek` advances the game clock (`Game.nextWeek()`), recalculates finances, updates training, records news items and creates a `PostMatchSummary`. The modal surfaces immediately, recreating the Kivy continue dialog.
+4. **Information screen** – After closing the modal the Information tab is selected, showing finances, news and board expectations. The **Continue week** button calls `advanceWeekWithoutMatch`, keeping the same single-entry flow the Kivy `WeeklyInformationScreen` uses.
+5. **Repeat** – Navigate through Training, Transfers or League at will, then return to Team for the next fixture.
+
+## Screen manager parity
+
+The web application swaps views using React state (`selectedTab`) instead of the original `ScreenManager`, but the order and behaviour remain the same:
+
+1. Start screen → New game screen → Main screen
+2. Main screen tabs:
+   - Team (with Match centre modal)
+   - Training
+   - Transfers (includes TransferTeam and TransferList interactions)
+   - Information (combining Finances and Weekly Information)
+   - League (Division tables)
+3. Manager stats overlay replicates the secondary screen reached by the manager icon in Kivy.
+
+The combination of these screens recreates the user experience of the Kivy build while benefiting from the underlying TypeScript engine.

--- a/docs/matches-and-training.md
+++ b/docs/matches-and-training.md
@@ -1,0 +1,36 @@
+# Matches and training
+
+Matches and weekly training form the backbone of SimpleFM's simulation loop. The web UI recreates the Kivy match screen while using the same TypeScript engine that drives outcomes and player development.
+
+## Match lifecycle
+
+1. **Scheduling** – `Game.startOfSeason()` builds fixtures for every division. `Team.nextMatch(week)` returns the `Match` object for the current week.
+2. **Launching a match** – Opening the match screen calls `useGameEngine.startLiveMatch()`. The hook stores the `Match` in `liveMatchRef`, clears previous timelines and flags the simulation as live.
+3. **Minute-by-minute simulation** –
+   - `onPlayMinute` calls `Match.playMinute()`, advances the internal clock and records `MatchEvent`s (goals, injuries, substitutions) for the timeline list.
+   - `onToggleAutoPlay` starts/stops an interval that repeatedly invokes `onPlayMinute`, mirroring the auto-play button in Kivy.
+   - `onMakeSubstitution` delegates to `Match.makeSubstitution` after verifying the change is legal.
+4. **Finishing the match** – `onFinishLiveMatch` stops auto-play, finalises the `Match`, stores it as `currentMatch` and hands it to `finalizeWeek`.
+5. **Instant simulation** – When the user skips the match and only presses **Continue week**, the engine invokes `advanceWeekWithoutMatch`, simulating every division in bulk—matching the desktop behaviour when you fast-forward from the weekly information screen.
+
+## Training updates
+
+Training is recalculated as part of `Team.weeklyUpdate()`:
+
+- Every player collects or loses training points based on match minutes (`player.weeklyTraining`).
+- `trainingToStr` converts the numeric change into the familiar labels (`++`, `+`, `-`, `--`).
+- Experienced starters grant tactical bonuses via `Team.titsTotalSkill()` and `Team.tacticalSkill()`.
+
+The Training screen simply renders these metrics, grouped by position, exactly as the Kivy `WeeklyTraining` list did.
+
+## Weekly summary
+
+After each week the engine produces a `PostMatchSummary` object via `createPostMatchSummary` (`webapp/src/hooks/postMatchSummary.ts`):
+
+- `match` – final score, venue, result and scorer list if a fixture happened.
+- `training` – extracted from each player’s weekly training delta.
+- `finances` – combination of the week's ledger entries (salaries, transfers, prize money, sponsors).
+- `news` – items from `Team.weeklyNews` such as injuries or forced sales.
+- `table` – a highlight row for each team in the human division.
+
+The modal enforces the same pause before continuing that the Kivy `WeeklyInformationScreen` provided, preserving the rhythm of match → news → continue.

--- a/docs/teams-and-players.md
+++ b/docs/teams-and-players.md
@@ -1,0 +1,31 @@
+# Teams and players
+
+The heart of SimpleFM is the `Team` class (`webapp/src/game/team.ts`). Each human club is a `Team` instance populated with `Player` objects (`webapp/src/game/player.ts`). The user interface mirrors the same structure used in the original Kivy widgets.
+
+## Team anatomy
+
+- **Roster (`players`)** – an array of `Player` objects sorted by position or status depending on the view.
+- **Playing status** – each player stores `playingStatus` (`0` = starter, `1` = bench, `2` = reserves). The Team screen groups players into the same three lists as the Kivy `TeamPlayersList` widget.
+- **Tactic (`currentTactic`)** – dynamically computed from starters if the club is human. Selecting a tactic in the UI calls `setPlayingTactic`, which validates formations and reorders the roster.
+- **Finances** – teams track `weeklyFinances` and `yearlyFinances`, updated when `setTransferList`, `weeklyUpdate` or transfer operations occur. These maps drive the Information screen summary.
+- **Morale and goals** – properties like `fanHappiness` and `seasonPointsPerWeek` capture board pressure. The helper `minPosPerSeasonPointsPerWeek()` converts the target points-per-week into a required league position.
+- **Transfer list** – `playersToBuy` is refreshed weekly via `setTransferList()`, just like the desktop game generating a fresh shortlist.
+- **Weekly news** – `weeklyNews` collects events (injuries, youth promotions, forced sales) written during `weeklyUpdate()`.
+
+## Player attributes
+
+Players have a rich set of properties that affect training, matches and transfers:
+
+- **Position (`position`)** – 0 = goalkeeper, 1 = defender, 2 = midfielder, 3 = forward. Helper methods such as `posToStr()` convert to display labels.
+- **Skill (`skill`)** – base ability used for formation calculations. During matches, `matchSkill()` adjusts this value by fatigue and bonuses.
+- **Age & retirement** – the engine tracks `age`, `retired` status and contract length (`contract`). Older players are weighted in `Team.titsTotalSkill()` to simulate experience bonuses.
+- **Availability** – `injured()`, `matchAvailable()` and contract state determine whether the UI shows warning styling and whether swaps are allowed.
+- **Financial metrics** – `salary` and `currentValue()` feed into wage and transfer calculations. Selling a player applies through `Team.sellPlayer`, which updates finances and news.
+
+## Interaction highlights
+
+- Swapping players updates both the `playingStatus` values and the computed tactic. This is why the UI forces users to tap one player and then another, replicating the Kivy list behaviour.
+- Adding a custom club sets colour, country and initial division/position; the roster is generated using `TEAM['STARTING_AMOUNT_OF_PLAYERS_PER_POS']` to ensure balanced squads.
+- Weekly updates adjust morale, trigger automatic sales if money drops below zero (`sellPlayerIfMoneyBelow0`) and reduce injuries/contracts, ensuring the persistent simulation lines up with the desktop version.
+
+These mechanics are surfaced through the React components (`SquadBoard`, `TrainingPanel`, `TransferHub`) so that every action mirrors the behaviour from the original GUI.

--- a/docs/transfers-and-finances.md
+++ b/docs/transfers-and-finances.md
@@ -1,0 +1,24 @@
+# Transfers, contracts and finances
+
+Transfers, contracts and club finances all stem from the same data structures used in the original Python game. The web interface surfaces these concepts through the Transfers and Information screens.
+
+## Transfer market
+
+- **Weekly shortlist** – `Team.setTransferList()` populates `playersToBuy` every week using the constants from `lib/constants` (mirrored in `webapp/src/game/constants.ts`). The web UI refreshes this list when you tap **Refresh list**.
+- **Buying players** – Selecting a target queues a confirmation card. `Team.buyPlayer()` (invoked via the hook) transfers the player, updates wages, and injects a "Bought Players" entry into weekly finances.
+- **Selling players** – Only players passing `player.canBeSold()` can be sold. Selling updates `Team.money`, appends a `News('Sold Player', name)` item and adjusts finances. If your balance drops below zero, `sellPlayerIfMoneyBelow0()` automatically forces a sale and the news feed reflects it.
+- **Contract renewals** – Renewals are handled by `Team.renewPlayerContract()`, extending the player's `contract` value and updating finances. The UI disables the button when a contract is not expiring, mirroring the desktop rule.
+
+## Financial model
+
+- **Accounts** – Teams maintain `weeklyFinances` and `yearlyFinances` dictionaries with keys `Salaries`, `Bought Players`, `Sold Players`, `Prize Money`, `Sponsors`. Weekly updates zero out certain values and roll them into the yearly ledger.
+- **Sponsorship and prize money** – Determined when creating the human team (`Game.createHumanTeam`). The initial sponsor payout depends on the chosen division/position.
+- **Weekly update** – `Team.weeklyUpdate()` applies salary payments, sponsor income, prize money, contract reductions and training adjustments. It also populates `weeklyNews` with events such as injuries, youth promotions and forced sales.
+- **Board expectations** – `Team.seasonPointsPerWeek` (derived from constants in `TEAM_GOALS`) defines the points-per-week target. `Team.minPosPerSeasonPointsPerWeek()` converts that into a minimum acceptable league position. The Information screen displays both metrics to replicate the Kivy board panel.
+
+## News and morale
+
+- **News feed** – `Team.weeklyNews.news` collects textual updates. The Information screen renders them verbatim so you see the same events the Kivy popups showed.
+- **Fan happiness** – Stored in `Team.fanHappiness`, influenced by results and finances. The Information screen shows the current value, and the weekly summary modal includes the same number.
+
+Together these mechanics guarantee the financial and transfer behaviour in the browser matches the established desktop experience.

--- a/webapp/app/globals.css
+++ b/webapp/app/globals.css
@@ -3,51 +3,114 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: radial-gradient(circle at top, #123b1f 0%, #081a0c 45%, #030a05 100%);
-  color: #f5f5f5;
+  color-scheme: light;
+  font-family: 'Roboto', 'Segoe UI', sans-serif;
+  color: #1a1a1a;
+  background-color: #062c18;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background-image: url('https://images.unsplash.com/photo-1461896836934-ffe607ba8211?auto=format&fit=crop&w=1600&q=80');
-  background-size: cover;
-  background-position: center;
+  background-color: #052314;
+  background-image:
+    radial-gradient(140% 100% at 15% 0%, rgba(18, 102, 55, 0.9) 0%, rgba(5, 35, 20, 0.5) 45%, rgba(1, 12, 6, 0.9) 100%),
+    radial-gradient(160% 120% at 85% 15%, rgba(11, 54, 30, 0.85) 0%, rgba(2, 17, 9, 0.65) 35%, rgba(1, 8, 4, 0.92) 100%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.02) 0%, rgba(255, 255, 255, 0.02) 45%, transparent 45%, transparent 55%, rgba(255, 255, 255, 0.02) 55%, rgba(255, 255, 255, 0.02) 100%);
+  background-blend-mode: screen, lighten, normal;
+  background-size: cover, cover, 140px 140px;
   background-attachment: fixed;
+  color: inherit;
 }
 
 main {
   min-height: 100vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
 }
 
-.card-surface {
-  @apply bg-midnight/85 backdrop-blur-md rounded-3xl shadow-card border border-white/10;
+.kivy-panel {
+  background: rgba(255, 255, 255, 0.93);
+  border-radius: 18px;
+  border: 2px solid rgba(0, 0, 0, 0.18);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
 }
 
-.pitch-gradient {
-  background: linear-gradient(135deg, rgba(15,59,27,0.92), rgba(18,92,43,0.88));
+.kivy-panel--flat {
+  box-shadow: none;
 }
 
-.nav-glow {
-  box-shadow: inset 0 0 0 1px rgba(245, 216, 103, 0.35), 0 8px 30px rgba(10, 20, 10, 0.65);
+.kivy-header {
+  background: rgba(20, 20, 20, 0.92);
+  border-radius: 14px;
+  border: 2px solid rgba(0, 0, 0, 0.6);
+  color: #ffffff;
 }
 
-.text-subtle {
-  color: rgba(240, 255, 240, 0.72);
+.kivy-footer {
+  background: rgba(255, 255, 255, 0.94);
+  border-top: 2px solid rgba(0, 0, 0, 0.18);
+  border-radius: 0 0 18px 18px;
 }
 
-.scrollbar-thin {
+.kivy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 2.75rem;
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: linear-gradient(180deg, #f5d767 0%, #e6b73a 100%);
+  color: #1f1400;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.2);
+}
+
+.kivy-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 22px rgba(0, 0, 0, 0.28);
+}
+
+.kivy-button:active {
+  transform: translateY(1px);
+}
+
+.kivy-button--secondary {
+  background: rgba(255, 255, 255, 0.95);
+  color: #1a1a1a;
+}
+
+.kivy-label {
+  color: #1a1a1a;
+}
+
+.kivy-subtle {
+  color: rgba(15, 15, 15, 0.65);
+}
+
+.kivy-list {
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.kivy-scroll {
   scrollbar-width: thin;
 }
 
-.scrollbar-thin::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+.kivy-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
 }
 
-.scrollbar-thin::-webkit-scrollbar-thumb {
-  background-color: rgba(245, 216, 103, 0.45);
+.kivy-scroll::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.25);
   border-radius: 9999px;
 }

--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <main className="flex min-h-screen flex-col items-center justify-start p-4 sm:p-8">
+        <main className="flex min-h-screen flex-col items-center justify-center p-4 sm:p-8">
           {children}
         </main>
       </body>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -29,7 +29,6 @@ export default function HomePage() {
     matchTimeline,
     autoPlaying,
     startLiveMatch,
-    playLiveMinute,
     toggleAutoPlay,
     finishLiveMatch,
     makeMatchSubstitution,
@@ -38,7 +37,9 @@ export default function HomePage() {
     sellPlayer,
     renewContract,
     postMatchSummary,
-    dismissPostMatchSummary
+    dismissPostMatchSummary,
+    matchPopup,
+    acknowledgeMatchPopup
   } = useGameEngine();
 
   type Screen = 'start' | 'new-game' | 'load-game' | 'career';
@@ -94,7 +95,6 @@ export default function HomePage() {
           matchTimeline={matchTimeline}
           autoPlaying={autoPlaying}
           onStartLiveMatch={startLiveMatch}
-          onPlayMinute={playLiveMinute}
           onToggleAutoPlay={toggleAutoPlay}
           onFinishLiveMatch={finishLiveMatch}
           onMakeSubstitution={makeMatchSubstitution}
@@ -105,6 +105,8 @@ export default function HomePage() {
           onResetCareer={handleReset}
           postMatchSummary={postMatchSummary}
           onDismissSummary={dismissPostMatchSummary}
+          matchPopup={matchPopup}
+          onAcknowledgePopup={acknowledgeMatchPopup}
         />
       )}
     </div>

--- a/webapp/src/components/GameDashboard.tsx
+++ b/webapp/src/components/GameDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { Game, Match, Player, Team } from '@/game';
-import type { MatchEvent, OperationResult, TabKey } from '@/hooks/useGameEngine';
+import type { MatchEvent, MatchPopup, OperationResult, TabKey } from '@/hooks/useGameEngine';
 import type { PostMatchSummary } from '@/hooks/postMatchSummary';
 import { SquadBoard } from './SquadBoard';
 import { TrainingPanel } from './TrainingPanel';
@@ -38,7 +38,6 @@ interface Props {
   matchTimeline: MatchEvent[];
   autoPlaying: boolean;
   onStartLiveMatch: () => OperationResult;
-  onPlayMinute: () => OperationResult;
   onToggleAutoPlay: () => OperationResult;
   onFinishLiveMatch: () => OperationResult;
   onMakeSubstitution: (playerOut: Player, playerIn: Player) => OperationResult;
@@ -49,6 +48,8 @@ interface Props {
   onResetCareer: () => void;
   postMatchSummary: PostMatchSummary | null;
   onDismissSummary: () => void;
+  matchPopup: MatchPopup | null;
+  onAcknowledgePopup: () => void;
 }
 
 const tabs: Array<{ key: TabKey; label: string }> = [
@@ -77,7 +78,6 @@ export function GameDashboard({
   matchTimeline,
   autoPlaying,
   onStartLiveMatch,
-  onPlayMinute,
   onToggleAutoPlay,
   onFinishLiveMatch,
   onMakeSubstitution,
@@ -87,7 +87,9 @@ export function GameDashboard({
   onRenewContract,
   onResetCareer,
   postMatchSummary,
-  onDismissSummary
+  onDismissSummary,
+  matchPopup,
+  onAcknowledgePopup
 }: Props) {
   const [feedback, setFeedback] = useState<{ message: string; tone: 'success' | 'error' | 'info' } | null>(null);
   const [showMatchScreen, setShowMatchScreen] = useState(false);
@@ -370,12 +372,12 @@ export function GameDashboard({
           autoPlaying={autoPlaying}
           timeline={matchTimeline}
           onStartLiveMatch={onStartLiveMatch}
-          onPlayMinute={onPlayMinute}
           onToggleAutoPlay={onToggleAutoPlay}
           onFinishLiveMatch={onFinishLiveMatch}
           onMakeSubstitution={onMakeSubstitution}
           onFeedback={showFeedback}
-          onClose={() => setShowMatchScreen(false)}
+          matchPopup={matchPopup}
+          onAcknowledgePopup={onAcknowledgePopup}
         />
       )}
 

--- a/webapp/src/components/LoadGameScreen.tsx
+++ b/webapp/src/components/LoadGameScreen.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+interface LoadGameScreenProps {
+  onBack: () => void;
+}
+
+export function LoadGameScreen({ onBack }: LoadGameScreenProps) {
+  return (
+    <div className="kivy-panel w-full max-w-3xl overflow-hidden">
+      <header className="kivy-header px-6 py-4 text-center text-lg font-semibold uppercase tracking-[0.3em]">
+        Load Game
+      </header>
+      <div className="space-y-4 px-6 py-6 text-sm">
+        <p>
+          The original SimpleFM prototype loads career saves from the local filesystem. The web port keeps the same flow, so loading
+          careers will be added when browser storage support is complete.
+        </p>
+        <p className="kivy-subtle">
+          For now, start a new game from the main menu. Career progress is kept only while this page remains open.
+        </p>
+      </div>
+      <footer className="kivy-footer flex justify-end gap-3 px-6 py-4">
+        <button type="button" className="kivy-button kivy-button--secondary" onClick={onBack}>
+          Back
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/webapp/src/components/ManagerStatsPanel.tsx
+++ b/webapp/src/components/ManagerStatsPanel.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { Manager } from '@/game';
+
+interface ManagerStatsPanelProps {
+  manager: Manager | null;
+  onClose: () => void;
+}
+
+export function ManagerStatsPanel({ manager, onClose }: ManagerStatsPanelProps) {
+  if (!manager) {
+    return (
+      <div className="flex h-full flex-col justify-between gap-4">
+        <div className="kivy-list p-6 text-sm">
+          <p>No human manager is currently assigned to this club.</p>
+        </div>
+        <div className="flex justify-end">
+          <button type="button" className="kivy-button kivy-button--secondary" onClick={onClose}>
+            Back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const order = manager.careerStatsOrder();
+  const careerStats = manager.careerStats();
+  const yearlyStats = manager.yearlyStats.slice().reverse();
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <section className="kivy-list p-4">
+        <h3 className="text-base font-semibold uppercase tracking-wide">Career stats</h3>
+        <div className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+          {order.map((label) => (
+            <div key={label} className="flex items-center justify-between rounded-lg border border-black/10 bg-white px-3 py-2">
+              <span className="font-semibold">{label}</span>
+              <span>{careerStats[label as keyof typeof careerStats]}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="kivy-list p-4">
+        <h3 className="text-base font-semibold uppercase tracking-wide">Yearly stats</h3>
+        <div className="mt-3 overflow-x-auto">
+          <table className="min-w-full border-separate border-spacing-y-1 text-left text-sm">
+            <thead>
+              <tr className="bg-white/70">
+                <th className="px-3 py-2">Season</th>
+                <th className="px-3 py-2">Division</th>
+                <th className="px-3 py-2">Pos</th>
+                <th className="px-3 py-2">Pts</th>
+                <th className="px-3 py-2">W</th>
+                <th className="px-3 py-2">D</th>
+                <th className="px-3 py-2">L</th>
+                <th className="px-3 py-2">GF</th>
+                <th className="px-3 py-2">GA</th>
+              </tr>
+            </thead>
+            <tbody>
+              {yearlyStats.length === 0 && (
+                <tr>
+                  <td colSpan={9} className="px-3 py-4 text-center text-sm">
+                    No completed seasons yet.
+                  </td>
+                </tr>
+              )}
+              {yearlyStats.map((season, index) => (
+                <tr key={`${season.div}-${index}`} className="bg-white/80">
+                  <td className="px-3 py-2">{yearlyStats.length - index}</td>
+                  <td className="px-3 py-2">{season.div}</td>
+                  <td className="px-3 py-2">{season.pos}</td>
+                  <td className="px-3 py-2">{season.pts}</td>
+                  <td className="px-3 py-2">{season.Wins}</td>
+                  <td className="px-3 py-2">{season.Draws}</td>
+                  <td className="px-3 py-2">{season.Losses}</td>
+                  <td className="px-3 py-2">{season['Goals For']}</td>
+                  <td className="px-3 py-2">{season['Goals Against']}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <div className="flex justify-end">
+        <button type="button" className="kivy-button kivy-button--secondary" onClick={onClose}>
+          Back
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/MatchCenter.tsx
+++ b/webapp/src/components/MatchCenter.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Game, Match, Player, Team } from '@/game';
-import type { MatchEvent, OperationResult } from '@/hooks/useGameEngine';
+import type { MatchEvent, MatchPopup, OperationResult } from '@/hooks/useGameEngine';
+import { displayRating } from '@/utils/ratings';
 
 interface MatchCenterProps {
   game: Game;
@@ -13,12 +14,12 @@ interface MatchCenterProps {
   autoPlaying: boolean;
   timeline: MatchEvent[];
   onStartLiveMatch: () => OperationResult;
-  onPlayMinute: () => OperationResult;
   onToggleAutoPlay: () => OperationResult;
   onFinishLiveMatch: () => OperationResult;
   onMakeSubstitution: (playerOut: Player, playerIn: Player) => OperationResult;
   onFeedback: (result: OperationResult) => void;
-  onClose: () => void;
+  matchPopup: MatchPopup | null;
+  onAcknowledgePopup: () => void;
 }
 
 function formatScore(match: Match | null): string {
@@ -37,19 +38,37 @@ export function MatchCenter({
   autoPlaying,
   timeline,
   onStartLiveMatch,
-  onPlayMinute,
   onToggleAutoPlay,
   onFinishLiveMatch,
   onMakeSubstitution,
   onFeedback,
-  onClose
+  matchPopup,
+  onAcknowledgePopup
 }: MatchCenterProps) {
   const [subOut, setSubOut] = useState<Player | null>(null);
   const [subIn, setSubIn] = useState<Player | null>(null);
+  const [finishReady, setFinishReady] = useState(false);
 
   const nextMatch = useMemo(() => team.nextMatch(game.week), [team, game.week]);
+  const nextOpponentName = useMemo(() => {
+    if (!nextMatch) {
+      return null;
+    }
+    const [home, away] = nextMatch.teams;
+    return home === team ? away.name : home.name;
+  }, [nextMatch, team]);
   const activeMatch = liveMatch ?? lastMatch ?? nextMatch;
-  const matchInProgress = !!liveMatch && !liveMatch.finished;
+  const matchFinished = !!liveMatch && liveMatch.finished;
+
+  useEffect(() => {
+    if (matchFinished) {
+      setFinishReady(false);
+      const timeout = setTimeout(() => setFinishReady(true), 1000);
+      return () => clearTimeout(timeout);
+    }
+    setFinishReady(false);
+    return undefined;
+  }, [matchFinished]);
 
   const starters = team.players
     .filter((player) => player.playingStatus === 0)
@@ -75,10 +94,6 @@ export function MatchCenter({
 
   const handleStart = () => {
     onFeedback(onStartLiveMatch());
-  };
-
-  const handlePlayMinute = () => {
-    onFeedback(onPlayMinute());
   };
 
   const handleToggleAutoPlay = () => {
@@ -124,19 +139,98 @@ export function MatchCenter({
 
   const minuteLabel = liveMatch ? `Minute ${liveMatch.minutes}` : nextMatch ? `Week ${game.week + 1}` : 'Match finished';
 
+  const kickoffAvailable = !isMatchLive && !matchFinished && !!nextMatch;
+  const goalInterlude = matchPopup?.type === 'goal' && isMatchLive && !autoPlaying;
+
+  let primaryLabel = 'Kick-off';
+  let primaryDisabled = false;
+  let primaryVariant: 'primary' | 'secondary' = 'primary';
+  let controlHint = '';
+
+  if (matchFinished) {
+    primaryLabel = finishReady ? 'End match' : 'Full time';
+    primaryDisabled = !finishReady;
+    primaryVariant = 'primary';
+    controlHint = finishReady
+      ? 'Wrap up the fixture to continue your week.'
+      : 'Final whistle! Preparing summary…';
+  } else if (isMatchLive) {
+    if (autoPlaying) {
+      primaryLabel = 'Pause';
+      primaryVariant = 'secondary';
+      controlHint = 'Stop auto-play to pause the simulation.';
+    } else {
+      primaryLabel = 'Play';
+      primaryVariant = 'primary';
+      primaryDisabled = goalInterlude;
+      controlHint = matchPopup?.type === 'halftime'
+        ? 'Start the second half when ready.'
+        : goalInterlude
+        ? 'Celebrating the goal…'
+        : 'Resume the live simulation.';
+    }
+  } else {
+    primaryLabel = 'Kick-off';
+    primaryVariant = 'primary';
+    primaryDisabled = !kickoffAvailable;
+    controlHint = kickoffAvailable
+      ? `Play week ${game.week + 1} against ${nextOpponentName ?? 'your opponent'}.`
+      : 'No fixture available this week.';
+  }
+
+  const primaryClass = `${
+    primaryVariant === 'primary' ? 'kivy-button' : 'kivy-button kivy-button--secondary'
+  } px-5 py-3 text-sm font-semibold uppercase tracking-wide disabled:cursor-not-allowed disabled:opacity-50`;
+
+  const handlePrimaryAction = () => {
+    if (matchFinished) {
+      if (finishReady) {
+        handleFinish();
+      }
+      return;
+    }
+    if (isMatchLive) {
+      if (autoPlaying) {
+        handleToggleAutoPlay();
+      } else {
+        if (matchPopup) {
+          onAcknowledgePopup();
+        }
+        handleToggleAutoPlay();
+      }
+      return;
+    }
+    if (kickoffAvailable) {
+      handleStart();
+    }
+  };
+
   return (
     <div className="fixed inset-0 z-40 overflow-y-auto bg-black/60 px-4 py-6">
-      <div className="kivy-panel mx-auto w-full max-w-5xl">
+      {matchPopup && (
+        <div className="pointer-events-none fixed inset-0 z-50 flex items-start justify-center pt-24">
+          <div className="pointer-events-auto w-full max-w-xs rounded-2xl border-2 border-[#f5d767]/80 bg-[#1c1d25]/95 px-6 py-4 text-center shadow-xl">
+            <p className="text-xs uppercase tracking-[0.3em] text-[#f5d767]/80">
+              {matchPopup.type === 'goal' ? 'Goal' : 'Half-time'}
+            </p>
+            <p className="mt-2 text-xl font-semibold text-white">{matchPopup.title}</p>
+            {matchPopup.message && <p className="mt-3 text-sm text-white/80">{matchPopup.message}</p>}
+            {matchPopup.type === 'halftime' && (
+              <p className="mt-3 text-xs uppercase text-[#f5d767]/80">Press play when you&apos;re ready.</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="kivy-panel relative mx-auto w-full max-w-5xl">
         <header className="kivy-header flex items-center justify-between px-6 py-4">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-[#f5d767]">Match screen</p>
             <p className="text-lg font-semibold text-white">{formatScore(activeMatch)}</p>
             <p className="text-xs text-white/80">{minuteLabel}</p>
           </div>
-          <div className="flex gap-2">
-            <button type="button" className="kivy-button kivy-button--secondary px-4 py-2 text-xs" onClick={onClose}>
-              Close
-            </button>
+          <div className="text-right text-xs uppercase tracking-[0.2em] text-white/70">
+            {matchFinished ? 'Full time' : isMatchLive ? (autoPlaying ? 'Auto-play running' : 'Match paused') : 'Awaiting kick-off'}
           </div>
         </header>
 
@@ -154,41 +248,11 @@ export function MatchCenter({
           </section>
 
           <section className="kivy-list flex flex-col gap-3 p-4 text-sm">
-            <h3 className="text-base font-semibold uppercase tracking-wide">Controls</h3>
-            <div className="flex flex-col gap-2">
-              <button
-                type="button"
-                className="kivy-button px-4 py-2 text-xs disabled:opacity-50"
-                onClick={handleStart}
-                disabled={!nextMatch || isMatchLive}
-              >
-                Kick-off
-              </button>
-              <button
-                type="button"
-                className="kivy-button kivy-button--secondary px-4 py-2 text-xs disabled:opacity-50"
-                onClick={handlePlayMinute}
-                disabled={!matchInProgress}
-              >
-                Play minute
-              </button>
-              <button
-                type="button"
-                className="kivy-button kivy-button--secondary px-4 py-2 text-xs disabled:opacity-50"
-                onClick={handleToggleAutoPlay}
-                disabled={!matchInProgress && !autoPlaying}
-              >
-                {autoPlaying ? 'Pause auto-play' : 'Auto-play'}
-              </button>
-              <button
-                type="button"
-                className="kivy-button kivy-button--secondary px-4 py-2 text-xs disabled:opacity-50"
-                onClick={handleFinish}
-                disabled={!liveMatch || !liveMatch.finished}
-              >
-                Finish match
-              </button>
-            </div>
+            <h3 className="text-base font-semibold uppercase tracking-wide">Match control</h3>
+            <button type="button" className={primaryClass} onClick={handlePrimaryAction} disabled={primaryDisabled}>
+              {primaryLabel}
+            </button>
+            <p className="kivy-subtle text-xs">{controlHint}</p>
           </section>
         </div>
 
@@ -210,7 +274,7 @@ export function MatchCenter({
                       <span className="font-semibold">{player.name}</span>
                       <span>{player.posToStr()}</span>
                     </div>
-                    <p className="kivy-subtle">Skill {player.skill.toFixed(1)} · Age {player.age}</p>
+                    <p className="kivy-subtle">Skill {displayRating(player.skill)} · Age {player.age}</p>
                   </button>
                 );
               })}
@@ -235,7 +299,7 @@ export function MatchCenter({
                       <span className="font-semibold">{player.name}</span>
                       <span>{player.posToStr()}</span>
                     </div>
-                    <p className="kivy-subtle">Skill {player.skill.toFixed(1)} · Contract {player.contract} weeks</p>
+                    <p className="kivy-subtle">Skill {displayRating(player.skill)} · Contract {player.contract} weeks</p>
                   </button>
                 );
               })}

--- a/webapp/src/components/MatchCenter.tsx
+++ b/webapp/src/components/MatchCenter.tsx
@@ -125,8 +125,8 @@ export function MatchCenter({
   const minuteLabel = liveMatch ? `Minute ${liveMatch.minutes}` : nextMatch ? `Week ${game.week + 1}` : 'Match finished';
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 px-4 py-6">
-      <div className="kivy-panel w-full max-w-5xl overflow-hidden">
+    <div className="fixed inset-0 z-40 overflow-y-auto bg-black/60 px-4 py-6">
+      <div className="kivy-panel mx-auto w-full max-w-5xl">
         <header className="kivy-header flex items-center justify-between px-6 py-4">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-[#f5d767]">Match screen</p>

--- a/webapp/src/components/MatchCenter.tsx
+++ b/webapp/src/components/MatchCenter.tsx
@@ -184,7 +184,7 @@ export function MatchCenter({
                 type="button"
                 className="kivy-button kivy-button--secondary px-4 py-2 text-xs disabled:opacity-50"
                 onClick={handleFinish}
-                disabled={!isMatchLive}
+                disabled={!liveMatch || !liveMatch.finished}
               >
                 Finish match
               </button>

--- a/webapp/src/components/NewGameForm.tsx
+++ b/webapp/src/components/NewGameForm.tsx
@@ -7,25 +7,26 @@ import type { NewGamePayload } from '@/hooks/useGameEngine';
 interface Props {
   availableTeams: string[];
   onStart: (payload: NewGamePayload) => void;
+  onCancel: () => void;
 }
 
-export function NewGameForm({ availableTeams, onStart }: Props) {
-  const [gameName, setGameName] = useState('My Federation');
-  const [managerName, setManagerName] = useState('Manager');
-  const [selectedTeam, setSelectedTeam] = useState<string>(availableTeams[0] ?? '');
+export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
+  const teamOptions = useMemo(() => ['Create new team', ...availableTeams], [availableTeams]);
+
+  const [gameName, setGameName] = useState('');
+  const [managerName, setManagerName] = useState('');
+  const [selectedTeam, setSelectedTeam] = useState<string>('Create new team');
   const [customName, setCustomName] = useState('');
   const [customCountry, setCustomCountry] = useState<string>(COUNTRIES[0]?.id ?? 'Eng');
   const [customColor, setCustomColor] = useState<string>(COLORS[0]?.hex ?? '#485C96');
+  const [customColorName, setCustomColorName] = useState<string>(COLORS[0]?.name ?? 'Blue');
   const [customDivision, setCustomDivision] = useState(1);
   const [customPosition, setCustomPosition] = useState(1);
   const [error, setError] = useState<string | null>(null);
 
-  const useCustomTeam = selectedTeam === 'Create custom club';
+  const useCustomTeam = selectedTeam === 'Create new team';
 
-  const teamOptions = useMemo(
-    () => ['Create custom club', ...availableTeams],
-    [availableTeams]
-  );
+  const resetError = () => setError(null);
 
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -40,7 +41,7 @@ export function NewGameForm({ availableTeams, onStart }: Props) {
 
     if (useCustomTeam) {
       if (!customName.trim()) {
-        setError('Custom club requires a name.');
+        setError('Please set a name for your new team.');
         return;
       }
       onStart({
@@ -68,136 +69,151 @@ export function NewGameForm({ availableTeams, onStart }: Props) {
   };
 
   return (
-    <form onSubmit={submit} className="card-surface w-full max-w-xl space-y-6 p-6 sm:p-10">
-      <div className="space-y-1">
-        <h2 className="text-2xl font-semibold text-accent">Take over a club</h2>
-        <p className="text-subtle text-sm">
-          Craft your legacy with a modern experience inspired by the golden age of online football managers.
-        </p>
-      </div>
-      <div className="grid gap-4">
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide text-subtle">Game name</span>
+    <form onSubmit={submit} className="kivy-panel w-full max-w-4xl overflow-hidden">
+      <header className="kivy-header px-6 py-4 text-center text-lg font-semibold uppercase tracking-[0.35em]">
+        New Game
+      </header>
+      <div className="space-y-6 px-6 py-6">
+        <div className="grid gap-3 sm:grid-cols-[0.85fr_1.15fr] sm:items-center">
+          <label className="text-sm font-semibold uppercase tracking-wide">Game name</label>
           <input
             value={gameName}
-            onChange={(event) => setGameName(event.target.value)}
-            className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
-            placeholder="Weekend Warriors"
+            onChange={(event) => {
+              resetError();
+              setGameName(event.target.value);
+            }}
+            placeholder="Max 16 characters"
+            maxLength={16}
+            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
           />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide text-subtle">Manager name</span>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-[0.85fr_1.15fr] sm:items-center">
+          <label className="text-sm font-semibold uppercase tracking-wide">Manager name</label>
           <input
             value={managerName}
-            onChange={(event) => setManagerName(event.target.value)}
-            className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
-            placeholder="Alex F."
+            onChange={(event) => {
+              resetError();
+              setManagerName(event.target.value);
+            }}
+            placeholder="Max 16 characters"
+            maxLength={16}
+            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
           />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide text-subtle">Select club</span>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-[0.85fr_1.15fr] sm:items-center">
+          <label className="text-sm font-semibold uppercase tracking-wide">Team</label>
           <select
             value={selectedTeam}
-            onChange={(event) => setSelectedTeam(event.target.value)}
-            className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
+            onChange={(event) => {
+              setSelectedTeam(event.target.value);
+              resetError();
+            }}
+            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
           >
             {teamOptions.map((team) => (
-              <option key={team} value={team} className="bg-midnight">
+              <option key={team} value={team}>
                 {team}
               </option>
             ))}
           </select>
-        </label>
-      </div>
+        </div>
 
-      {useCustomTeam && (
-        <div className="rounded-2xl border border-white/5 bg-white/5 p-4 backdrop-blur">
-          <h3 className="text-lg font-semibold text-accent">Custom club</h3>
-          <p className="text-xs text-subtle">Choose your identity, formation placement and home colors.</p>
-          <div className="mt-4 grid gap-3 sm:grid-cols-2">
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide text-subtle">Club name</span>
-              <input
-                value={customName}
-                onChange={(event) => setCustomName(event.target.value)}
-                className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
-                placeholder="Greendale Rovers"
-              />
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide text-subtle">Country</span>
-              <select
-                value={customCountry}
-                onChange={(event) => setCustomCountry(event.target.value)}
-                className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
-              >
-                {COUNTRIES.map((country) => (
-                  <option key={country.id} value={country.id} className="bg-midnight">
-                    {country.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide text-subtle">Division</span>
-              <select
-                value={customDivision}
-                onChange={(event) => setCustomDivision(Number(event.target.value))}
-                className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
-              >
-                {Array.from({ length: COMPETITION['TOTAL_NUMBER_OF_DIVISIONS'] }, (_, index) => index + 1).map((value) => (
-                  <option key={value} value={value} className="bg-midnight">
-                    League {value}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-xs uppercase tracking-wide text-subtle">Previous position</span>
-              <select
-                value={customPosition}
-                onChange={(event) => setCustomPosition(Number(event.target.value))}
-                className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
-              >
-                {Array.from({ length: COMPETITION['TEAMS PER DIVISION'] }, (_, index) => index + 1).map((value) => (
-                  <option key={value} value={value} className="bg-midnight">
-                    {value}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="flex flex-col gap-1 sm:col-span-2">
-              <span className="text-xs uppercase tracking-wide text-subtle">Primary color</span>
-              <div className="flex items-center gap-3">
-                <div
-                  className="h-9 w-9 rounded-full border border-white/20"
-                  style={{ background: customColor }}
+        {useCustomTeam && (
+          <div className="rounded-2xl border-2 border-black/10 bg-white/90 p-4">
+            <h3 className="text-base font-semibold uppercase tracking-wide">Create new team</h3>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-semibold uppercase tracking-wide">Name</span>
+                <input
+                  value={customName}
+                  onChange={(event) => {
+                    setCustomName(event.target.value);
+                    resetError();
+                  }}
+                  placeholder="Max 16 characters"
+                  maxLength={16}
+                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
                 />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-semibold uppercase tracking-wide">Country</span>
                 <select
-                  value={customColor}
-                  onChange={(event) => setCustomColor(event.target.value)}
-                  className="flex-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none"
+                  value={customCountry}
+                  onChange={(event) => setCustomCountry(event.target.value)}
+                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
                 >
-                  {COLORS.map((color) => (
-                    <option key={color.name} value={color.hex} className="bg-midnight">
-                      {color.name}
+                  {COUNTRIES.map((country) => (
+                    <option key={country.id} value={country.id}>
+                      {country.name}
                     </option>
                   ))}
                 </select>
-              </div>
-            </label>
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-semibold uppercase tracking-wide">Division</span>
+                <select
+                  value={customDivision}
+                  onChange={(event) => setCustomDivision(Number(event.target.value))}
+                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                >
+                  {Array.from({ length: COMPETITION['TOTAL_NUMBER_OF_DIVISIONS'] }, (_, index) => index + 1).map((value) => (
+                    <option key={value} value={value}>
+                      {value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-semibold uppercase tracking-wide">Position</span>
+                <select
+                  value={customPosition}
+                  onChange={(event) => setCustomPosition(Number(event.target.value))}
+                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                >
+                  {Array.from({ length: COMPETITION['TEAMS PER DIVISION'] }, (_, index) => index + 1).map((value) => (
+                    <option key={value} value={value}>
+                      {value}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+                <span className="font-semibold uppercase tracking-wide">Team color</span>
+                <div className="flex items-center gap-3">
+                  <div className="h-9 w-9 rounded-full border-2 border-black/15" style={{ background: customColor }} />
+                  <select
+                    value={customColorName}
+                    onChange={(event) => {
+                      const color = COLORS.find((entry) => entry.name === event.target.value);
+                      if (color) {
+                        setCustomColor(color.hex);
+                        setCustomColorName(color.name);
+                      }
+                    }}
+                    className="flex-1 rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                  >
+                    {COLORS.map((color) => (
+                      <option key={color.name} value={color.name}>
+                        {color.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </label>
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {error && <p className="text-sm font-medium text-red-400">{error}</p>}
-
-      <button
-        type="submit"
-        className="w-full rounded-full bg-accent/90 py-3 text-sm font-semibold uppercase tracking-wider text-midnight transition hover:bg-accent"
-      >
-        Start my journey
-      </button>
+        {error && <p className="text-sm font-semibold text-red-600">{error}</p>}
+      </div>
+      <footer className="kivy-footer flex items-center justify-end gap-3 px-6 py-4">
+        <button type="button" className="kivy-button kivy-button--secondary" onClick={onCancel}>
+          Back
+        </button>
+        <button type="submit" className="kivy-button">
+          Create Game
+        </button>
+      </footer>
     </form>
   );
 }

--- a/webapp/src/components/PostMatchSummary.tsx
+++ b/webapp/src/components/PostMatchSummary.tsx
@@ -1,26 +1,19 @@
 'use client';
 
 import type { PostMatchSummary } from '@/hooks/postMatchSummary';
+import { getTrainingIndicator } from '@/utils/training';
 
 interface Props {
   summary: PostMatchSummary;
   onClose: () => void;
 }
 
-const trainingColors: Record<PostMatchSummary['training'][number]['label'], string> = {
-  '': 'text-black/70',
-  '++': 'text-emerald-700',
-  '+': 'text-emerald-600',
-  '-': 'text-amber-600',
-  '--': 'text-red-600'
-};
-
 export function PostMatchSummaryModal({ summary, onClose }: Props) {
   const { match, training, finances, news, table } = summary;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-6">
-      <div className="kivy-panel w-full max-w-4xl overflow-hidden">
+    <div className="fixed inset-0 z-50 overflow-y-auto bg-black/60 px-4 py-6">
+      <div className="kivy-panel mx-auto w-full max-w-4xl overflow-hidden">
         <header className="kivy-header flex items-center justify-between px-6 py-4">
           <div>
             <h2 className="text-lg font-semibold uppercase tracking-[0.3em]">Week {summary.week} summary</h2>
@@ -74,12 +67,18 @@ export function PostMatchSummaryModal({ summary, onClose }: Props) {
                 {training.map((item) => (
                   <li
                     key={`${item.player}-${item.position}-${item.amount}`}
-                    className="rounded-lg border border-black/15 bg-white px-3 py-2 flex items-center justify-between"
+                    className="flex items-center justify-between rounded-lg border border-black/15 bg-white px-3 py-2"
                   >
                     <span>{item.player} · {item.position}</span>
-                    <span className={`${trainingColors[item.label]} font-semibold`}>
-                      {item.label} ({item.amount.toFixed(2)})
-                    </span>
+                    {(() => {
+                      const indicator = getTrainingIndicator(item.label);
+                      return (
+                        <span className={`${indicator.className} font-semibold`}>
+                          <span aria-hidden="true">{indicator.icon}</span>
+                          <span className="sr-only">{indicator.description}</span>
+                        </span>
+                      );
+                    })()}
                   </li>
                 ))}
               </ul>

--- a/webapp/src/components/PostMatchSummary.tsx
+++ b/webapp/src/components/PostMatchSummary.tsx
@@ -8,117 +8,107 @@ interface Props {
 }
 
 const trainingColors: Record<PostMatchSummary['training'][number]['label'], string> = {
-  '': 'text-subtle',
-  '++': 'text-emerald-300',
-  '+': 'text-emerald-200',
-  '-': 'text-amber-200',
-  '--': 'text-red-300'
+  '': 'text-black/70',
+  '++': 'text-emerald-700',
+  '+': 'text-emerald-600',
+  '-': 'text-amber-600',
+  '--': 'text-red-600'
 };
 
 export function PostMatchSummaryModal({ summary, onClose }: Props) {
   const { match, training, finances, news, table } = summary;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-midnight/80 px-4 py-6">
-      <div className="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-3xl border border-white/10 bg-[#0b1220] p-6 shadow-xl">
-        <div className="flex flex-col gap-5">
-          <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="text-xl font-semibold text-white">Week {summary.week} summary</h2>
-              <p className="text-xs text-subtle">
-                Season {summary.season} · Fan happiness {Math.round(summary.fanHappiness)} · Balance €
-                {summary.balance.toLocaleString()}
-              </p>
-            </div>
-            <button
-              onClick={onClose}
-              className="rounded-full bg-accent/90 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-midnight transition hover:bg-accent"
-            >
-              Continue
-            </button>
-          </header>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-6">
+      <div className="kivy-panel w-full max-w-4xl overflow-hidden">
+        <header className="kivy-header flex items-center justify-between px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold uppercase tracking-[0.3em]">Week {summary.week} summary</h2>
+            <p className="text-xs text-white/80">
+              Season {summary.season} · Fan happiness {Math.round(summary.fanHappiness)} · Balance €
+              {summary.balance.toLocaleString()}
+            </p>
+          </div>
+          <button type="button" className="kivy-button px-6 py-2 text-xs" onClick={onClose}>
+            Continue
+          </button>
+        </header>
 
-          {match ? (
-            <section className="rounded-3xl border border-white/10 bg-white/5 p-5">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="grid gap-4 px-6 py-6 md:grid-cols-2">
+          <section className="kivy-list p-4 md:col-span-2">
+            <h3 className="text-base font-semibold uppercase tracking-wide">Match</h3>
+            {match ? (
+              <div className="mt-3 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-subtle">Result</p>
-                  <p className="text-lg font-semibold text-white">
-                    {match.home} {match.score[0]} - {match.score[1]} {match.away}
-                  </p>
-                  <p className="text-xs text-subtle">
+                  <p className="text-xl font-semibold text-black">{match.home} {match.score[0]} - {match.score[1]} {match.away}</p>
+                  <p className="kivy-subtle text-sm">
                     {match.venue} · {match.result}
                   </p>
                 </div>
-                <div className="rounded-2xl border border-white/10 bg-midnight/60 px-3 py-2 text-xs text-subtle">
-                  <p>Goals</p>
+                <div className="kivy-list kivy-panel--flat border border-black/10 bg-white px-3 py-2 text-sm">
+                  <p className="font-semibold">Goals</p>
                   {match.scorers.length === 0 ? (
-                    <p className="mt-1 text-white/70">No goals recorded.</p>
+                    <p className="kivy-subtle text-xs">No goals recorded.</p>
                   ) : (
-                    <ul className="mt-1 space-y-1 text-white/80">
+                    <ul className="mt-2 space-y-1 text-xs">
                       {match.scorers.map((goal, index) => (
                         <li key={`${goal.minute}-${goal.team}-${index}`}>
-                          <span className="text-accent">{goal.minute}&apos;</span> {goal.scorer} ({goal.team})
+                          <span className="font-semibold text-black/80">{goal.minute}&apos;</span> {goal.scorer} ({goal.team})
                         </li>
                       ))}
                     </ul>
                   )}
                 </div>
               </div>
-            </section>
-          ) : (
-            <section className="rounded-3xl border border-white/10 bg-white/5 p-5 text-sm text-subtle">
-              No fixture took place this week. Your staff still processed contracts, finances and training.
-            </section>
-          )}
-
-          <section className="grid gap-4 md:grid-cols-2">
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
-              <h3 className="text-sm font-semibold text-accent">Training highlights</h3>
-              {training.length === 0 ? (
-                <p className="mt-3 text-xs text-subtle">No notable training changes this week.</p>
-              ) : (
-                <ul className="mt-3 space-y-2 text-xs text-subtle">
-                  {training.map((item) => (
-                    <li
-                      key={`${item.player}-${item.position}-${item.amount}`}
-                      className="flex items-center justify-between rounded-2xl border border-white/10 bg-midnight/60 px-3 py-2"
-                    >
-                      <span className="text-white">
-                        {item.player} · {item.position}
-                      </span>
-                      <span className={`${trainingColors[item.label]} font-semibold`}>
-                        {item.label} ({item.amount.toFixed(2)})
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
-              <h3 className="text-sm font-semibold text-accent">Finances</h3>
-              {finances.length === 0 ? (
-                <p className="mt-3 text-xs text-subtle">No financial movement recorded this week.</p>
-              ) : (
-                <ul className="mt-3 space-y-2 text-xs text-subtle">
-                  {finances.map((line) => (
-                    <li key={line.label} className="flex items-center justify-between rounded-2xl bg-midnight/60 px-3 py-2">
-                      <span className="text-white">{line.label}</span>
-                      <span className={line.amount >= 0 ? 'text-emerald-300' : 'text-red-300'}>
-                        €{line.amount.toLocaleString()}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+            ) : (
+              <p className="kivy-subtle mt-3 text-sm">No fixture took place this week. Staff still processed finances and training.</p>
+            )}
           </section>
 
-          <section className="rounded-3xl border border-white/10 bg-white/5 p-4">
-            <h3 className="text-sm font-semibold text-accent">League table</h3>
-            <div className="mt-3 overflow-hidden rounded-2xl border border-white/10">
-              <table className="min-w-full divide-y divide-white/10 text-left text-xs text-subtle">
-                <thead className="bg-white/5 uppercase">
+          <section className="kivy-list p-4">
+            <h3 className="text-base font-semibold uppercase tracking-wide">Training highlights</h3>
+            {training.length === 0 ? (
+              <p className="kivy-subtle mt-2 text-sm">No notable training changes this week.</p>
+            ) : (
+              <ul className="kivy-scroll mt-3 max-h-40 space-y-2 overflow-y-auto text-sm">
+                {training.map((item) => (
+                  <li
+                    key={`${item.player}-${item.position}-${item.amount}`}
+                    className="rounded-lg border border-black/15 bg-white px-3 py-2 flex items-center justify-between"
+                  >
+                    <span>{item.player} · {item.position}</span>
+                    <span className={`${trainingColors[item.label]} font-semibold`}>
+                      {item.label} ({item.amount.toFixed(2)})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="kivy-list p-4">
+            <h3 className="text-base font-semibold uppercase tracking-wide">Finances</h3>
+            {finances.length === 0 ? (
+              <p className="kivy-subtle mt-2 text-sm">No financial movement recorded this week.</p>
+            ) : (
+              <ul className="kivy-scroll mt-3 max-h-40 space-y-2 overflow-y-auto text-sm">
+                {finances.map((line) => (
+                  <li key={line.label} className="rounded-lg border border-black/15 bg-white px-3 py-2 flex items-center justify-between">
+                    <span>{line.label}</span>
+                    <span className={line.amount >= 0 ? 'text-emerald-700 font-semibold' : 'text-red-600 font-semibold'}>
+                      €{line.amount.toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="kivy-list p-4">
+            <h3 className="text-base font-semibold uppercase tracking-wide">League table</h3>
+            <div className="kivy-scroll mt-3 max-h-48 overflow-y-auto">
+              <table className="min-w-full border-separate border-spacing-y-1 text-left text-xs">
+                <thead className="bg-white/80 uppercase">
                   <tr>
                     <th className="px-3 py-2">Pos</th>
                     <th className="px-3 py-2">Club</th>
@@ -126,13 +116,10 @@ export function PostMatchSummaryModal({ summary, onClose }: Props) {
                     <th className="px-3 py-2">GD</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-white/10">
+                <tbody>
                   {table.map((row) => (
-                    <tr
-                      key={`${row.position}-${row.name}`}
-                      className={row.highlight ? 'bg-accent/20 text-white' : 'text-subtle hover:bg-white/5'}
-                    >
-                      <td className="px-3 py-2 font-semibold text-accent">{row.position}</td>
+                    <tr key={`${row.position}-${row.name}`} className={row.highlight ? 'bg-[#f5d767]/60 font-semibold' : 'bg-white/95'}>
+                      <td className="px-3 py-2">{row.position}</td>
                       <td className="px-3 py-2">{row.name}</td>
                       <td className="px-3 py-2">{row.points}</td>
                       <td className="px-3 py-2">{row.goalDifference}</td>
@@ -140,7 +127,7 @@ export function PostMatchSummaryModal({ summary, onClose }: Props) {
                   ))}
                   {table.length === 0 && (
                     <tr>
-                      <td colSpan={4} className="px-3 py-4 text-center text-subtle">
+                      <td colSpan={4} className="px-3 py-4 text-center text-sm">
                         League standings unavailable this week.
                       </td>
                     </tr>
@@ -150,14 +137,14 @@ export function PostMatchSummaryModal({ summary, onClose }: Props) {
             </div>
           </section>
 
-          <section className="rounded-3xl border border-white/10 bg-white/5 p-4">
-            <h3 className="text-sm font-semibold text-accent">Club news</h3>
+          <section className="kivy-list p-4 md:col-span-2">
+            <h3 className="text-base font-semibold uppercase tracking-wide">Club news</h3>
             {news.length === 0 ? (
-              <p className="mt-3 text-xs text-subtle">The press office had nothing to report.</p>
+              <p className="kivy-subtle mt-2 text-sm">The press office had nothing to report.</p>
             ) : (
-              <ul className="mt-3 space-y-2 text-xs text-subtle">
+              <ul className="kivy-scroll mt-3 max-h-40 space-y-2 overflow-y-auto text-sm">
                 {news.map((item, index) => (
-                  <li key={`${item}-${index}`} className="rounded-2xl bg-midnight/60 px-3 py-2 text-white/80">
+                  <li key={`${item}-${index}`} className="rounded-lg border border-black/15 bg-white px-3 py-2">
                     {item}
                   </li>
                 ))}

--- a/webapp/src/components/SquadBoard.tsx
+++ b/webapp/src/components/SquadBoard.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import type { Player, Team } from '@/game';
 import type { OperationResult } from '@/hooks/useGameEngine';
+import { displayRating } from '@/utils/ratings';
 
 interface SquadBoardProps {
   team: Team;
@@ -130,7 +131,7 @@ export function SquadBoard({ team, allowedTactics, currentTactic, onSetTactic, o
                       <span>{positionLabel(player.position)}</span>
                     </div>
                     <p className="kivy-subtle text-xs">
-                      Skill {player.skill.toFixed(1)} · Age {player.age} · Wage €{player.salary.toLocaleString()}
+                      Skill {displayRating(player.skill)} · Age {player.age} · Wage €{player.salary.toLocaleString()}
                     </p>
                     <p className="text-[0.7rem] text-black/60">
                       {player.injured() ? 'Injured' : player.matchAvailable() ? 'Available' : 'Unavailable'}

--- a/webapp/src/components/SquadBoard.tsx
+++ b/webapp/src/components/SquadBoard.tsx
@@ -14,9 +14,9 @@ interface SquadBoardProps {
 }
 
 const STATUS_CONFIG: Array<{ label: string; status: number; description: string }> = [
-  { label: 'Starting XI', status: 0, description: 'Players on the pitch.' },
-  { label: 'Bench', status: 1, description: 'Available substitutes.' },
-  { label: 'Reserves', status: 2, description: 'Outside the matchday squad.' }
+  { label: 'Starting XI', status: 0, description: 'Players currently selected for the match.' },
+  { label: 'Bench', status: 1, description: 'Players available as substitutes.' },
+  { label: 'Reserves', status: 2, description: 'Players outside the matchday squad.' }
 ];
 
 function tacticLabel(tactic: number[]): string {
@@ -30,14 +30,7 @@ function positionLabel(position: number): string {
   return 'FW';
 }
 
-export function SquadBoard({
-  team,
-  allowedTactics,
-  currentTactic,
-  onSetTactic,
-  onSwapPlayers,
-  onFeedback
-}: SquadBoardProps) {
+export function SquadBoard({ team, allowedTactics, currentTactic, onSetTactic, onSwapPlayers, onFeedback }: SquadBoardProps) {
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
 
   const tacticOptions = useMemo(() => {
@@ -48,8 +41,6 @@ export function SquadBoard({
     return Array.from(unique.entries()).map(([label, tactic]) => ({ label, tactic }));
   }, [allowedTactics]);
 
-  const currentTacticLabel = currentTactic.length > 0 ? tacticLabel(currentTactic) : 'Auto';
-
   const groupedPlayers = STATUS_CONFIG.map((config) => ({
     ...config,
     players: team.players
@@ -57,6 +48,23 @@ export function SquadBoard({
       .slice()
       .sort((a, b) => b.skill - a.skill)
   }));
+
+  const currentTacticLabel = useMemo(() => {
+    const label = tacticLabel(currentTactic);
+    if (tacticOptions.some((option) => option.label === label)) {
+      return label;
+    }
+    return tacticOptions[0]?.label ?? '';
+  }, [currentTactic, tacticOptions]);
+
+  const handleTacticChange = (label: string) => {
+    const entry = tacticOptions.find((option) => option.label === label);
+    if (!entry) {
+      return;
+    }
+    const result = onSetTactic(entry.tactic);
+    onFeedback(result);
+  };
 
   const handleSelect = (player: Player) => {
     if (!selectedPlayer) {
@@ -72,48 +80,40 @@ export function SquadBoard({
     setSelectedPlayer(null);
   };
 
-  const handleTacticClick = (tactic: number[]) => {
-    const result = onSetTactic(tactic);
-    onFeedback(result);
-    setSelectedPlayer(null);
-  };
-
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-4">
+      <div className="kivy-list flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-subtle">Formation</h3>
-          <p className="text-lg font-semibold text-white">Current: {currentTacticLabel}</p>
+          <h3 className="text-base font-semibold uppercase tracking-wide">Formation</h3>
+          <p className="kivy-subtle text-sm">Select a tactic to organise your matchday squad.</p>
         </div>
-        <div className="flex flex-wrap gap-2">
-          {tacticOptions.map(({ label, tactic }) => {
-            const active = label === currentTacticLabel;
-            return (
-              <button
-                key={label}
-                onClick={() => handleTacticClick(tactic)}
-                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition ${
-                  active ? 'bg-accent/90 text-midnight' : 'border border-white/20 text-subtle hover:border-accent hover:text-white'
-                }`}
-              >
+        <div className="flex items-center gap-3">
+          <label className="text-xs font-semibold uppercase tracking-wide">Tactic</label>
+          <select
+            value={currentTacticLabel}
+            onChange={(event) => handleTacticChange(event.target.value)}
+            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+          >
+            {tacticOptions.map(({ label }) => (
+              <option key={label} value={label}>
                 {label}
-              </button>
-            );
-          })}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-3">
         {groupedPlayers.map((group) => (
-          <div key={group.label} className="rounded-3xl border border-white/10 bg-white/5 p-4">
+          <div key={group.label} className="kivy-list p-4">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="text-sm font-semibold text-accent">{group.label}</h3>
-                <p className="text-xs text-subtle">{group.description}</p>
+                <h4 className="text-base font-semibold uppercase tracking-wide">{group.label}</h4>
+                <p className="kivy-subtle text-xs">{group.description}</p>
               </div>
-              <span className="text-xs text-subtle">{group.players.length} players</span>
+              <span className="text-xs font-semibold text-black/60">{group.players.length}</span>
             </div>
-            <div className="mt-3 flex flex-col gap-2">
+            <div className="kivy-scroll mt-3 max-h-72 space-y-2 overflow-y-auto">
               {group.players.map((player) => {
                 const isSelected = selectedPlayer === player;
                 const unavailable = !player.matchAvailable();
@@ -121,36 +121,28 @@ export function SquadBoard({
                   <button
                     key={`${player.name}-${player.age}-${player.position}`}
                     onClick={() => handleSelect(player)}
-                    className={`flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-left transition ${
-                      isSelected
-                        ? 'border-accent bg-accent/20 text-white'
-                        : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                    className={`w-full rounded-lg border px-3 py-2 text-left text-sm ${
+                      isSelected ? 'border-[#f5d767] bg-[#f5d767]/40' : 'border-black/15 bg-white hover:border-[#f5d767]'
                     } ${unavailable ? 'opacity-60' : ''}`}
                   >
-                    <div className="flex items-center gap-3">
-                      <span className="rounded-full bg-midnight/70 px-2 py-1 text-xs font-semibold text-accent">
-                        {positionLabel(player.position)}
-                      </span>
-                      <div>
-                        <p className="text-sm font-semibold text-white">{player.name}</p>
-                        <p className="text-xs text-subtle">
-                          Skill {player.skill.toFixed(1)} · Age {player.age} · Wage €{player.salary.toLocaleString()}
-                        </p>
-                      </div>
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{player.name}</span>
+                      <span>{positionLabel(player.position)}</span>
                     </div>
-                    <div className="text-xs text-subtle">
+                    <p className="kivy-subtle text-xs">
+                      Skill {player.skill.toFixed(1)} · Age {player.age} · Wage €{player.salary.toLocaleString()}
+                    </p>
+                    <p className="text-[0.7rem] text-black/60">
                       {player.injured() ? 'Injured' : player.matchAvailable() ? 'Available' : 'Unavailable'}
-                    </div>
+                    </p>
                   </button>
                 );
               })}
               {group.players.length === 0 && (
-                <p className="rounded-2xl border border-dashed border-white/10 px-3 py-6 text-center text-xs text-subtle">
-                  No players in this group.
-                </p>
+                <p className="kivy-subtle text-sm">No players in this group.</p>
               )}
             </div>
-            <p className="mt-3 text-[0.7rem] text-subtle">
+            <p className="kivy-subtle mt-3 text-xs">
               Tap once to select a player, then tap another player to swap their match status.
             </p>
           </div>

--- a/webapp/src/components/StartScreen.tsx
+++ b/webapp/src/components/StartScreen.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+interface StartScreenProps {
+  onNewGame: () => void;
+  onLoadGame: () => void;
+}
+
+export function StartScreen({ onNewGame, onLoadGame }: StartScreenProps) {
+  return (
+    <div className="flex w-full max-w-xl flex-col items-center gap-8 text-center">
+      <div className="w-full rounded-3xl border-2 border-black/20 bg-black/70 px-10 py-12 shadow-xl">
+        <div className="flex flex-col items-center gap-6">
+          <h1
+            className="text-4xl font-bold tracking-wide text-white"
+            style={{ textShadow: '0 3px 6px rgba(0,0,0,0.6)' }}
+          >
+            Simple FM
+          </h1>
+          <p className="max-w-sm text-sm text-white/80">
+            The original desktop flow recreated for the web. Manage your squad, train your talents and climb the league ladder one week at a time.
+          </p>
+          <div className="flex w-full flex-col gap-3">
+            <button type="button" className="kivy-button" onClick={onNewGame}>
+              New Game
+            </button>
+            <button type="button" className="kivy-button kivy-button--secondary" onClick={onLoadGame}>
+              Load Game
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/TrainingPanel.tsx
+++ b/webapp/src/components/TrainingPanel.tsx
@@ -2,20 +2,13 @@
 
 import { useMemo } from 'react';
 import type { Team } from '@/game';
-import { trainingToStr, type TrainingDelta } from '@/game/helpers';
+import { trainingToStr } from '@/game/helpers';
+import { displayRating } from '@/utils/ratings';
+import { getTrainingIndicator } from '@/utils/training';
 
 interface TrainingPanelProps {
   team: Team;
 }
-
-const trainingColors: Record<TrainingDelta | '·', string> = {
-  '++': 'text-emerald-700',
-  '+': 'text-emerald-600',
-  '-': 'text-amber-600',
-  '--': 'text-red-600',
-  '': 'text-black/60',
-  '·': 'text-black/60'
-};
 
 export function TrainingPanel({ team }: TrainingPanelProps) {
   const players = useMemo(
@@ -43,7 +36,6 @@ export function TrainingPanel({ team }: TrainingPanelProps) {
               <th className="px-3 py-2">Name</th>
               <th className="px-3 py-2">Age</th>
               <th className="px-3 py-2">Skill</th>
-              <th className="px-3 py-2">Training</th>
               <th className="px-3 py-2">Trend</th>
             </tr>
           </thead>
@@ -53,14 +45,14 @@ export function TrainingPanel({ team }: TrainingPanelProps) {
                 <td className="px-3 py-2 font-semibold text-black/80">{player.posToStr()}</td>
                 <td className="px-3 py-2 font-semibold text-black/80">{player.name}</td>
                 <td className="px-3 py-2 text-black/70">{player.age}</td>
-                <td className="px-3 py-2 text-black/70">{player.skill.toFixed(1)}</td>
-                <td className="px-3 py-2 text-black/70">{player.weeklyTraining.toFixed(2)}</td>
+                <td className="px-3 py-2 text-black/70">{displayRating(player.skill)}</td>
                 {(() => {
                   const label = trainingToStr(player.weeklyTraining);
-                  const token: TrainingDelta | '·' = label === '' ? '·' : label;
+                  const indicator = getTrainingIndicator(label);
                   return (
-                    <td className={`px-3 py-2 font-semibold ${trainingColors[token]}`}>
-                      {token}
+                    <td className={`px-3 py-2 font-semibold ${indicator.className}`}>
+                      <span aria-hidden="true">{indicator.icon}</span>
+                      <span className="sr-only">{indicator.description}</span>
                     </td>
                   );
                 })()}
@@ -68,7 +60,7 @@ export function TrainingPanel({ team }: TrainingPanelProps) {
             ))}
             {players.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-3 py-6 text-center text-sm">
+                <td colSpan={5} className="px-3 py-6 text-center text-sm">
                   No training data recorded this week.
                 </td>
               </tr>

--- a/webapp/src/components/TrainingPanel.tsx
+++ b/webapp/src/components/TrainingPanel.tsx
@@ -9,12 +9,12 @@ interface TrainingPanelProps {
 }
 
 const trainingColors: Record<TrainingDelta | '·', string> = {
-  '++': 'text-emerald-300',
-  '+': 'text-emerald-200',
-  '-': 'text-amber-200',
-  '--': 'text-red-300',
-  '': 'text-subtle',
-  '·': 'text-subtle'
+  '++': 'text-emerald-700',
+  '+': 'text-emerald-600',
+  '-': 'text-amber-600',
+  '--': 'text-red-600',
+  '': 'text-black/60',
+  '·': 'text-black/60'
 };
 
 export function TrainingPanel({ team }: TrainingPanelProps) {
@@ -27,17 +27,17 @@ export function TrainingPanel({ team }: TrainingPanelProps) {
   );
 
   return (
-    <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+    <div className="kivy-list p-4">
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-sm font-semibold text-accent">Weekly training report</h3>
-          <p className="text-xs text-subtle">Improvements and regressions based on match minutes.</p>
+          <h3 className="text-base font-semibold uppercase tracking-wide">Weekly training report</h3>
+          <p className="kivy-subtle text-sm">Improvements and regressions based on match minutes.</p>
         </div>
-        <span className="text-xs text-subtle">{players.length} players</span>
+        <span className="text-xs font-semibold text-black/60">{players.length} players</span>
       </div>
-      <div className="mt-3 overflow-x-auto">
-        <table className="min-w-full divide-y divide-white/10 text-left text-xs text-subtle">
-          <thead className="bg-white/5 uppercase">
+      <div className="kivy-scroll mt-3 max-h-[26rem] overflow-y-auto">
+        <table className="min-w-full border-separate border-spacing-y-1 text-left text-sm">
+          <thead className="bg-white/80 text-xs uppercase">
             <tr>
               <th className="px-3 py-2">Pos</th>
               <th className="px-3 py-2">Name</th>
@@ -47,14 +47,14 @@ export function TrainingPanel({ team }: TrainingPanelProps) {
               <th className="px-3 py-2">Trend</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-white/10">
+          <tbody>
             {players.map((player) => (
-              <tr key={`${player.name}-${player.age}-${player.position}`} className="hover:bg-white/5">
-                <td className="px-3 py-2 text-white">{player.posToStr()}</td>
-                <td className="px-3 py-2 text-white">{player.name}</td>
-                <td className="px-3 py-2">{player.age}</td>
-                <td className="px-3 py-2">{player.skill.toFixed(1)}</td>
-                <td className="px-3 py-2">{player.weeklyTraining.toFixed(2)}</td>
+              <tr key={`${player.name}-${player.age}-${player.position}`} className="bg-white/95">
+                <td className="px-3 py-2 font-semibold text-black/80">{player.posToStr()}</td>
+                <td className="px-3 py-2 font-semibold text-black/80">{player.name}</td>
+                <td className="px-3 py-2 text-black/70">{player.age}</td>
+                <td className="px-3 py-2 text-black/70">{player.skill.toFixed(1)}</td>
+                <td className="px-3 py-2 text-black/70">{player.weeklyTraining.toFixed(2)}</td>
                 {(() => {
                   const label = trainingToStr(player.weeklyTraining);
                   const token: TrainingDelta | '·' = label === '' ? '·' : label;
@@ -68,7 +68,7 @@ export function TrainingPanel({ team }: TrainingPanelProps) {
             ))}
             {players.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-3 py-6 text-center text-subtle">
+                <td colSpan={6} className="px-3 py-6 text-center text-sm">
                   No training data recorded this week.
                 </td>
               </tr>

--- a/webapp/src/components/TransferHub.tsx
+++ b/webapp/src/components/TransferHub.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import type { Player, Team } from '@/game';
 import type { OperationResult } from '@/hooks/useGameEngine';
+import { displayRating } from '@/utils/ratings';
 
 interface TransferHubProps {
   team: Team;
@@ -96,7 +97,7 @@ export function TransferHub({ team, onRefresh, onBuy, onSell, onRenew, onFeedbac
                     <div>
                       <p className="font-semibold">{player.name}</p>
                       <p className="kivy-subtle text-xs">
-                        {player.posToStr()} · Skill {player.skill.toFixed(0)} · Wage {formatMoney(player.salary)}
+                        {player.posToStr()} · Skill {displayRating(player.skill)} · Wage {formatMoney(player.salary)}
                       </p>
                     </div>
                     <span className="text-sm font-semibold text-black/70">{formatMoney(player.currentValue())}</span>
@@ -153,7 +154,7 @@ export function TransferHub({ team, onRefresh, onBuy, onSell, onRenew, onFeedbac
                     <div>
                       <p className="font-semibold">{player.name}</p>
                       <p className="kivy-subtle text-xs">
-                        {player.posToStr()} · Skill {player.skill.toFixed(0)} · Value {formatMoney(player.currentValue())}
+                        {player.posToStr()} · Skill {displayRating(player.skill)} · Value {formatMoney(player.currentValue())}
                       </p>
                       <p className="kivy-subtle text-xs">Contract: {contractLabel}</p>
                     </div>

--- a/webapp/src/components/TransferHub.tsx
+++ b/webapp/src/components/TransferHub.tsx
@@ -38,20 +38,12 @@ export function TransferHub({ team, onRefresh, onBuy, onSell, onRenew, onFeedbac
     onFeedback(onRefresh());
   };
 
-  const handleBuy = (player: Player) => {
-    setSelectedTransfer(player);
-  };
-
   const handleConfirmBuy = () => {
     if (!selectedTransfer) {
       return;
     }
     onFeedback(onBuy(selectedTransfer));
     setSelectedTransfer(null);
-  };
-
-  const handleSell = (player: Player) => {
-    setSelectedSquad(player);
   };
 
   const handleConfirmSell = () => {
@@ -67,158 +59,150 @@ export function TransferHub({ team, onRefresh, onBuy, onSell, onRenew, onFeedbac
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-4">
+      <div className="kivy-list flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-subtle">Transfer war room</h3>
-          <p className="text-xs text-subtle">
-            Budget: {formatMoney(team.money)} · Weekly wages: {formatMoney(team.playersSalarySum())}
+          <h3 className="text-base font-semibold uppercase tracking-wide">Transfers</h3>
+          <p className="kivy-subtle text-sm">
+            Budget {formatMoney(team.money)} · Weekly wages {formatMoney(team.playersSalarySum())}
           </p>
         </div>
-        <button
-          onClick={handleRefresh}
-          className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/80 transition hover:border-accent hover:text-accent"
-        >
-          Refresh transfer list
+        <button type="button" className="kivy-button kivy-button--secondary px-6 py-2 text-xs" onClick={handleRefresh}>
+          Refresh list
         </button>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <section className="kivy-list p-4">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-sm font-semibold text-accent">Available signings</h3>
-              <p className="text-xs text-subtle">Players scouted this week.</p>
+              <h4 className="text-base font-semibold uppercase tracking-wide">Available signings</h4>
+              <p className="kivy-subtle text-xs">Scouted players ready to negotiate.</p>
             </div>
-            <span className="text-xs text-subtle">{transferTargets.length}</span>
+            <span className="text-xs font-semibold text-black/60">{transferTargets.length}</span>
           </div>
-          <div className="mt-3 space-y-2">
-            {transferTargets.map((player) => (
-              <button
-                key={`target-${player.name}-${player.age}`}
-                onClick={() => handleBuy(player)}
-                className={`flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-left text-xs transition ${
-                  selectedTransfer === player
-                    ? 'border-accent bg-accent/20 text-white'
-                    : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
-                }`}
-              >
-                <div>
-                  <p className="text-sm font-semibold text-white">{player.name}</p>
-                  <p className="text-xs text-subtle">
-                    {player.posToStr()} · Skill {player.skill.toFixed(0)} · Wage {formatMoney(player.salary)}
-                  </p>
-                </div>
-                <span className="text-sm font-semibold text-accent">{formatMoney(player.currentValue())}</span>
-              </button>
-            ))}
-            {transferTargets.length === 0 && (
-              <p className="rounded-2xl border border-dashed border-white/10 px-3 py-6 text-center text-xs text-subtle">
-                No players currently listed.
-              </p>
-            )}
+          <div className="kivy-scroll mt-3 max-h-80 space-y-2 overflow-y-auto">
+            {transferTargets.map((player) => {
+              const active = selectedTransfer === player;
+              return (
+                <button
+                  key={`target-${player.name}-${player.age}`}
+                  onClick={() => setSelectedTransfer(player)}
+                  className={`w-full rounded-lg border px-3 py-2 text-left text-sm ${
+                    active ? 'border-[#f5d767] bg-[#f5d767]/40' : 'border-black/15 bg-white hover:border-[#f5d767]'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-semibold">{player.name}</p>
+                      <p className="kivy-subtle text-xs">
+                        {player.posToStr()} · Skill {player.skill.toFixed(0)} · Wage {formatMoney(player.salary)}
+                      </p>
+                    </div>
+                    <span className="text-sm font-semibold text-black/70">{formatMoney(player.currentValue())}</span>
+                  </div>
+                </button>
+              );
+            })}
+            {transferTargets.length === 0 && <p className="kivy-subtle text-sm">No players currently listed.</p>}
           </div>
           {selectedTransfer && (
-            <div className="mt-3 rounded-2xl border border-white/10 bg-white/10 p-3 text-xs text-white/80">
-              <p className="font-semibold text-accent">Confirm signing</p>
-              <p className="mt-1">
-                Sign {selectedTransfer.name} for {formatMoney(selectedTransfer.currentValue())}? Their weekly wage demand is
+            <div className="mt-3 rounded-lg border border-black/15 bg-white px-3 py-3 text-sm">
+              <p className="font-semibold">Confirm signing</p>
+              <p className="kivy-subtle text-xs">
+                Sign {selectedTransfer.name} for {formatMoney(selectedTransfer.currentValue())}? Weekly wage request:
                 {formatMoney(selectedTransfer.salary)}.
               </p>
-              <div className="mt-2 flex gap-2">
-                <button
-                  onClick={handleConfirmBuy}
-                  className="rounded-full bg-accent/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-midnight"
-                >
+              <div className="mt-3 flex gap-2">
+                <button type="button" className="kivy-button px-4 py-2 text-xs" onClick={handleConfirmBuy}>
                   Confirm
                 </button>
                 <button
+                  type="button"
+                  className="kivy-button kivy-button--secondary px-4 py-2 text-xs"
                   onClick={() => setSelectedTransfer(null)}
-                  className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/70"
                 >
                   Cancel
                 </button>
               </div>
             </div>
           )}
-        </div>
+        </section>
 
-        <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+        <section className="kivy-list p-4">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-sm font-semibold text-accent">Your squad</h3>
-              <p className="text-xs text-subtle">Manage contracts and departures.</p>
+              <h4 className="text-base font-semibold uppercase tracking-wide">Your squad</h4>
+              <p className="kivy-subtle text-xs">Manage contracts and departures.</p>
             </div>
-            <span className="text-xs text-subtle">{team.players.length}</span>
+            <span className="text-xs font-semibold text-black/60">{team.players.length}</span>
           </div>
-          <div className="mt-3 space-y-2">
+          <div className="kivy-scroll mt-3 max-h-80 space-y-2 overflow-y-auto">
             {squadPlayers.map((player) => {
+              const selected = selectedSquad === player;
               const canSell = player.canBeSold();
               const contractLabel = player.contract > 0 ? `${player.contract} weeks` : 'Expiring';
               return (
                 <div
                   key={`squad-${player.name}-${player.age}`}
-                  className={`flex flex-col gap-2 rounded-2xl border px-3 py-2 text-xs transition sm:flex-row sm:items-center sm:justify-between ${
-                    selectedSquad === player
-                      ? 'border-accent bg-accent/20 text-white'
-                      : 'border-white/10 bg-white/5 text-subtle hover:border-accent hover:text-white'
+                  className={`rounded-lg border px-3 py-2 text-sm ${
+                    selected ? 'border-[#f5d767] bg-[#f5d767]/40' : 'border-black/15 bg-white'
                   }`}
                 >
-                  <div>
-                    <p className="text-sm font-semibold text-white">{player.name}</p>
-                    <p className="text-xs text-subtle">
-                      {player.posToStr()} · Skill {player.skill.toFixed(0)} · Value {formatMoney(player.currentValue())}
-                    </p>
-                    <p className="text-xs text-subtle">Contract: {contractLabel}</p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      onClick={() => handleSell(player)}
-                      disabled={!canSell}
-                      className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/80 transition hover:border-red-400 hover:text-red-200 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
-                    >
-                      Sell
-                    </button>
-                    <button
-                      onClick={() => handleRenew(player)}
-                      disabled={player.contract > 0}
-                      className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/80 transition hover:border-emerald-400 hover:text-emerald-200 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
-                    >
-                      Renew
-                    </button>
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="font-semibold">{player.name}</p>
+                      <p className="kivy-subtle text-xs">
+                        {player.posToStr()} · Skill {player.skill.toFixed(0)} · Value {formatMoney(player.currentValue())}
+                      </p>
+                      <p className="kivy-subtle text-xs">Contract: {contractLabel}</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedSquad(player)}
+                        disabled={!canSell}
+                        className="kivy-button kivy-button--secondary px-4 py-2 text-xs disabled:opacity-50"
+                      >
+                        Sell
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRenew(player)}
+                        disabled={player.contract > 0}
+                        className="kivy-button kivy-button--secondary px-4 py-2 text-xs disabled:opacity-50"
+                      >
+                        Renew
+                      </button>
+                    </div>
                   </div>
                 </div>
               );
             })}
-            {squadPlayers.length === 0 && (
-              <p className="rounded-2xl border border-dashed border-white/10 px-3 py-6 text-center text-xs text-subtle">
-                No registered players.
-              </p>
-            )}
+            {squadPlayers.length === 0 && <p className="kivy-subtle text-sm">No registered players.</p>}
           </div>
           {selectedSquad && (
-            <div className="mt-3 rounded-2xl border border-white/10 bg-white/10 p-3 text-xs text-white/80">
-              <p className="font-semibold text-accent">Confirm sale</p>
-              <p className="mt-1">
-                Sell {selectedSquad.name} for {formatMoney(selectedSquad.currentValue())}? This action is final.
+            <div className="mt-3 rounded-lg border border-black/15 bg-white px-3 py-3 text-sm">
+              <p className="font-semibold">Confirm sale</p>
+              <p className="kivy-subtle text-xs">
+                Sell {selectedSquad.name} for {formatMoney(selectedSquad.currentValue())}? Weekly wage relief:
+                {formatMoney(selectedSquad.salary)}.
               </p>
-              <div className="mt-2 flex gap-2">
-                <button
-                  onClick={handleConfirmSell}
-                  className="rounded-full bg-red-500/80 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white"
-                >
+              <div className="mt-3 flex gap-2">
+                <button type="button" className="kivy-button px-4 py-2 text-xs" onClick={handleConfirmSell}>
                   Confirm
                 </button>
                 <button
+                  type="button"
+                  className="kivy-button kivy-button--secondary px-4 py-2 text-xs"
                   onClick={() => setSelectedSquad(null)}
-                  className="rounded-full border border-white/20 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide text-white/70"
                 >
                   Cancel
                 </button>
               </div>
             </div>
           )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/webapp/src/hooks/gamePersistence.ts
+++ b/webapp/src/hooks/gamePersistence.ts
@@ -635,7 +635,8 @@ export function persistGameState({
   matchTimeline,
   isMatchLive,
   autoPlaying,
-  postMatchSummary
+  postMatchSummary,
+  matchPopup
 }: PersistInput): void {
   if (typeof window === 'undefined') {
     return;

--- a/webapp/src/hooks/gamePersistence.ts
+++ b/webapp/src/hooks/gamePersistence.ts
@@ -1,0 +1,750 @@
+'use client';
+
+import {
+  Division,
+  Game,
+  Manager,
+  Match,
+  Player,
+  Team,
+  type GoalRecord,
+  type PlayerLeagueStats
+} from '@/game';
+import { News, NewsList, type NewsCategory } from '@/game/news';
+import type { Finances, LeagueStats } from '@/game/team';
+import type { MatchEvent, TabKey } from './useGameEngine';
+import type { PostMatchSummary } from './postMatchSummary';
+
+const STORAGE_KEY = 'simplefm:career-state';
+
+interface SerializedNews {
+  category: NewsCategory;
+  data: string | number;
+}
+
+interface SerializedPlayer {
+  id: string;
+  skill: number;
+  country: string | null;
+  training: number;
+  weeklyTraining: number;
+  name: string;
+  age: number;
+  salary: number;
+  position: number;
+  playingStatus: number;
+  leagueStats: PlayerLeagueStats | null;
+  retired: boolean;
+  contract: number;
+  wantsNewContract: boolean;
+  weeklyStats: Record<string, unknown> | null;
+  wantedSalary: number | null;
+  injury: number;
+  matchMinutes: number;
+  subMinutes: number;
+  isHomegrown: boolean;
+  skillChangeLastWeek: number;
+}
+
+interface SerializedTeam {
+  id: string;
+  name: string;
+  country: string;
+  color: string | [number, number, number, number];
+  tactic: number[];
+  avgSkill: number;
+  players: SerializedPlayer[];
+  playersToBuy: SerializedPlayer[];
+  human: boolean;
+  leagueStats: LeagueStats;
+  weeklyFinances: Finances;
+  yearlyFinances: Finances;
+  money: number;
+  weeklySponsorship: number;
+  fanHappiness: number;
+  seasonPointsPerWeek: number;
+  weeklyNews: SerializedNews[];
+}
+
+interface SerializedMatchPlayer extends SerializedPlayer {
+  playerId: string | null;
+  teamId: string | null;
+}
+
+interface SerializedMatch {
+  matchId: string | null;
+  teamIds: [string, string];
+  minutes: number;
+  score: [number, number];
+  possession: [number, number];
+  possessionLast5Minutes: number[];
+  tacticalChanges: [number, number];
+  finished: boolean;
+  substitutions: [number, number];
+  goalscorers: Array<{
+    minute: number;
+    teamId: string;
+    player: SerializedMatchPlayer;
+  }>;
+  injuredPlayerOut: { teamId: string | null; player: SerializedMatchPlayer } | null;
+  isNeutralField: boolean;
+}
+
+interface SerializedDivision {
+  index: number;
+  name: string;
+  level: number;
+  teamIds: string[];
+  playable: boolean;
+  matches: SerializedMatch[][];
+}
+
+interface SerializedManager {
+  name: string;
+  teamId: string | null;
+  human: boolean;
+  yearlyStats: Manager['yearlyStats'];
+}
+
+interface SerializedGame {
+  name: string;
+  week: number;
+  season: number;
+  ended: boolean;
+  lastScreen: string;
+  divisions: SerializedDivision[];
+  teams: SerializedTeam[];
+  managers: SerializedManager[];
+  humanTeamIds: string[];
+}
+
+interface SerializedMatchRef {
+  id: string | null;
+  snapshot: SerializedMatch | null;
+}
+
+interface PersistedPayload {
+  game: SerializedGame | null;
+  currentMatch: SerializedMatchRef;
+  liveMatch: SerializedMatchRef;
+  selectedTab: TabKey;
+  weekNews: string[];
+  matchTimeline: MatchEvent[];
+  isMatchLive: boolean;
+  autoPlaying: boolean;
+  postMatchSummary: PostMatchSummary | null;
+}
+
+interface PersistInput {
+  game: Game | null;
+  currentMatch: Match | null;
+  liveMatch: Match | null;
+  selectedTab: TabKey;
+  weekNews: string[];
+  matchTimeline: MatchEvent[];
+  isMatchLive: boolean;
+  autoPlaying: boolean;
+  postMatchSummary: PostMatchSummary | null;
+}
+
+interface RehydratedState {
+  game: Game;
+  matchMap: Map<string, Match>;
+  teamMap: Map<string, Team>;
+  playerMap: Map<string, Player>;
+}
+
+interface LoadedState {
+  game: Game | null;
+  matchMap: Map<string, Match>;
+  teamMap: Map<string, Team>;
+  playerMap: Map<string, Player>;
+  currentMatch: Match | null;
+  liveMatch: Match | null;
+  selectedTab: TabKey;
+  weekNews: string[];
+  matchTimeline: MatchEvent[];
+  isMatchLive: boolean;
+  autoPlaying: boolean;
+  postMatchSummary: PostMatchSummary | null;
+}
+
+function cloneLeagueStats(stats: LeagueStats): LeagueStats {
+  return {
+    Wins: stats.Wins,
+    Draws: stats.Draws,
+    Losses: stats.Losses,
+    'Goals For': stats['Goals For'],
+    'Goals Against': stats['Goals Against']
+  };
+}
+
+function cloneFinances(finances: Finances): Finances {
+  return {
+    Salaries: finances.Salaries,
+    'Bought Players': finances['Bought Players'],
+    'Sold Players': finances['Sold Players'],
+    'Prize Money': finances['Prize Money'],
+    Sponsors: finances.Sponsors
+  };
+}
+
+function serializePlayer(player: Player, id: string, playerIdMap: Map<Player, string>): SerializedPlayer {
+  playerIdMap.set(player, id);
+  return {
+    id,
+    skill: player.skill,
+    country: player.country,
+    training: player.training,
+    weeklyTraining: player.weeklyTraining,
+    name: player.name,
+    age: player.age,
+    salary: player.salary,
+    position: player.position,
+    playingStatus: player.playingStatus,
+    leagueStats: player.leagueStats ? { ...player.leagueStats } : null,
+    retired: player.retired,
+    contract: player.contract,
+    wantsNewContract: player.wantsNewContract,
+    weeklyStats: player.weeklyStats ? { ...player.weeklyStats } : null,
+    wantedSalary: player.wantedSalary ?? null,
+    injury: player.injury,
+    matchMinutes: player.matchMinutes,
+    subMinutes: player.subMinutes,
+    isHomegrown: player.isHomegrown,
+    skillChangeLastWeek: player.skillChangeLastWeek
+  };
+}
+
+function serializeTeam(team: Team, id: string, playerIdMap: Map<Player, string>): SerializedTeam {
+  const players = team.players.map((player, index) => serializePlayer(player, `${id}-p${index}`, playerIdMap));
+  const playersToBuy = team.playersToBuy.map((player, index) =>
+    serializePlayer(player, `${id}-b${index}`, playerIdMap)
+  );
+  const weeklyNews: SerializedNews[] = team.weeklyNews.news.map((item) => ({
+    category: item.category,
+    data: item.data
+  }));
+
+  return {
+    id,
+    name: team.name,
+    country: team.country,
+    color: team.color,
+    tactic: [...team.tactic],
+    avgSkill: team.avgSkill,
+    players,
+    playersToBuy,
+    human: team.human,
+    leagueStats: cloneLeagueStats(team.leagueStats),
+    weeklyFinances: cloneFinances(team.weeklyFinances),
+    yearlyFinances: cloneFinances(team.yearlyFinances),
+    money: team.money,
+    weeklySponsorship: team.weeklySponsorship,
+    fanHappiness: team.fanHappiness,
+    seasonPointsPerWeek: team.seasonPointsPerWeek,
+    weeklyNews
+  };
+}
+
+function serializeMatchPlayer(
+  player: Player,
+  fallbackTeam: Team | null,
+  teamIdMap: Map<Team, string>,
+  playerIdMap: Map<Player, string>
+): SerializedMatchPlayer {
+  const playerId = playerIdMap.get(player) ?? null;
+  const team = player.team ?? fallbackTeam;
+  const teamId = team ? teamIdMap.get(team) ?? null : null;
+  const assignedId = playerId ?? `${teamId ?? 'match'}-${player.name}-${player.age}`;
+  const base = serializePlayer(player, assignedId, playerIdMap);
+  return {
+    ...base,
+    playerId: assignedId,
+    teamId
+  };
+}
+
+function serializeGoalRecord(
+  goal: GoalRecord,
+  teamIdMap: Map<Team, string>,
+  playerIdMap: Map<Player, string>
+): { minute: number; teamId: string; player: SerializedMatchPlayer } {
+  const teamId = teamIdMap.get(goal.team);
+  if (!teamId) {
+    throw new Error('Unable to resolve team when serializing goal record.');
+  }
+  return {
+    minute: goal.minute,
+    teamId,
+    player: serializeMatchPlayer(goal.player, goal.team, teamIdMap, playerIdMap)
+  };
+}
+
+function serializeMatch(
+  match: Match,
+  ensureTeam: (team: Team) => string,
+  teamIdMap: Map<Team, string>,
+  playerIdMap: Map<Player, string>,
+  matchId: string | null
+): SerializedMatch {
+  const teamIds: [string, string] = [ensureTeam(match.teams[0]), ensureTeam(match.teams[1])];
+  return {
+    matchId,
+    teamIds,
+    minutes: match.minutes,
+    score: [match.score[0], match.score[1]],
+    possession: [match.possession[0], match.possession[1]],
+    possessionLast5Minutes: [...match.possessionLast5Minutes],
+    tacticalChanges: [match.tacticalChanges[0], match.tacticalChanges[1]],
+    finished: match.finished,
+    substitutions: [match.substitutions[0], match.substitutions[1]],
+    goalscorers: match.goalscorers.map((goal) => serializeGoalRecord(goal, teamIdMap, playerIdMap)),
+    injuredPlayerOut: match.injuredPlayerOut
+      ? {
+          teamId: match.injuredPlayerOut.team ? ensureTeam(match.injuredPlayerOut.team) : null,
+          player: serializeMatchPlayer(
+            match.injuredPlayerOut,
+            match.injuredPlayerOut.team,
+            teamIdMap,
+            playerIdMap
+          )
+        }
+      : null,
+    isNeutralField: match.isNeutralField
+  };
+}
+
+function serializeGame(game: Game): { serialized: SerializedGame; teamIdMap: Map<Team, string>; playerIdMap: Map<Player, string> } {
+  const teamIdMap = new Map<Team, string>();
+  const playerIdMap = new Map<Player, string>();
+  const serializedTeams: SerializedTeam[] = [];
+
+  const ensureTeam = (team: Team): string => {
+    let id = teamIdMap.get(team);
+    if (id) {
+      return id;
+    }
+    id = `team-${teamIdMap.size}`;
+    teamIdMap.set(team, id);
+    serializedTeams.push(serializeTeam(team, id, playerIdMap));
+    return id;
+  };
+
+  game.divisions.forEach((division) => {
+    division.teams.forEach((team) => {
+      ensureTeam(team);
+    });
+  });
+  game.humanTeams.forEach((team) => ensureTeam(team));
+
+  const serializedDivisions: SerializedDivision[] = game.divisions.map((division, divisionIndex) => ({
+    index: divisionIndex,
+    name: division.name,
+    level: division.level,
+    teamIds: division.teams.map((team) => ensureTeam(team)),
+    playable: division.playable,
+    matches: division.matches.map((week, weekIndex) =>
+      week.map((match, matchIndex) =>
+        serializeMatch(
+          match,
+          ensureTeam,
+          teamIdMap,
+          playerIdMap,
+          `${divisionIndex}-${weekIndex}-${matchIndex}`
+        )
+      )
+    )
+  }));
+
+  const serializedManagers: SerializedManager[] = game.managers.map((manager) => ({
+    name: manager.name,
+    teamId: manager.team ? ensureTeam(manager.team) : null,
+    human: manager.human,
+    yearlyStats: manager.yearlyStats.map((stats) => ({ ...stats }))
+  }));
+
+  return {
+    serialized: {
+      name: game.name,
+      week: game.week,
+      season: game.season,
+      ended: game.ended,
+      lastScreen: game.lastScreen,
+      divisions: serializedDivisions,
+      teams: serializedTeams,
+      managers: serializedManagers,
+      humanTeamIds: game.humanTeams.map((team) => ensureTeam(team))
+    },
+    teamIdMap,
+    playerIdMap
+  };
+}
+
+function revivePlayer(data: SerializedPlayer, team: Team | null): Player {
+  return Object.assign(Object.create(Player.prototype), {
+    skill: data.skill,
+    country: data.country,
+    training: data.training,
+    weeklyTraining: data.weeklyTraining,
+    name: data.name,
+    age: data.age,
+    salary: data.salary,
+    position: data.position,
+    playingStatus: data.playingStatus,
+    leagueStats: data.leagueStats ? { ...data.leagueStats } : null,
+    retired: data.retired,
+    contract: data.contract,
+    wantsNewContract: data.wantsNewContract,
+    weeklyStats: data.weeklyStats ? { ...data.weeklyStats } : null,
+    wantedSalary: data.wantedSalary,
+    injury: data.injury,
+    matchMinutes: data.matchMinutes,
+    subMinutes: data.subMinutes,
+    isHomegrown: data.isHomegrown,
+    skillChangeLastWeek: data.skillChangeLastWeek,
+    team
+  }) as Player;
+}
+
+function reviveMatchPlayer(
+  data: SerializedMatchPlayer,
+  teamMap: Map<string, Team>,
+  playerMap: Map<string, Player>
+): Player {
+  if (data.playerId) {
+    const existing = playerMap.get(data.playerId);
+    if (existing) {
+      return existing;
+    }
+  }
+  const team = data.teamId ? teamMap.get(data.teamId) ?? null : null;
+  const player = revivePlayer(data, team);
+  if (data.playerId) {
+    playerMap.set(data.playerId, player);
+  }
+  return player;
+}
+
+function reviveMatch(
+  data: SerializedMatch,
+  teamMap: Map<string, Team>,
+  playerMap: Map<string, Player>,
+  matchIdMap: Map<string, Match>
+): Match {
+  const teamA = teamMap.get(data.teamIds[0]);
+  const teamB = teamMap.get(data.teamIds[1]);
+  if (!teamA || !teamB) {
+    throw new Error('Unable to revive match because a team is missing.');
+  }
+
+  const match = Object.assign(Object.create(Match.prototype), {
+    teams: [teamA, teamB] as [Team, Team],
+    minutes: data.minutes,
+    score: [data.score[0], data.score[1]] as [number, number],
+    possession: [data.possession[0], data.possession[1]] as [number, number],
+    possessionLast5Minutes: [...data.possessionLast5Minutes],
+    tacticalChanges: [data.tacticalChanges[0], data.tacticalChanges[1]] as [number, number],
+    finished: data.finished,
+    substitutions: [data.substitutions[0], data.substitutions[1]] as [number, number],
+    goalscorers: [] as GoalRecord[],
+    injuredPlayerOut: null as Player | null,
+    isNeutralField: data.isNeutralField
+  }) as Match;
+
+  match.goalscorers = data.goalscorers.map((entry) => ({
+    minute: entry.minute,
+    team: teamMap.get(entry.teamId) ?? teamA,
+    player: reviveMatchPlayer(entry.player, teamMap, playerMap)
+  }));
+
+  match.injuredPlayerOut = data.injuredPlayerOut
+    ? reviveMatchPlayer(data.injuredPlayerOut.player, teamMap, playerMap)
+    : null;
+
+  if (data.matchId) {
+    matchIdMap.set(data.matchId, match);
+  }
+
+  return match;
+}
+
+function reviveTeam(data: SerializedTeam, playerMap: Map<string, Player>): Team {
+  const weeklyNews = new NewsList(data.weeklyNews.map((item) => new News(item.category, item.data)));
+  const team = Object.assign(Object.create(Team.prototype), {
+    name: data.name,
+    country: data.country,
+    color: data.color,
+    manager: null,
+    division: null,
+    tactic: [...data.tactic],
+    avgSkill: data.avgSkill,
+    players: [] as Player[],
+    human: data.human,
+    leagueStats: cloneLeagueStats(data.leagueStats),
+    playersToBuy: [] as Player[],
+    weeklyFinances: cloneFinances(data.weeklyFinances),
+    yearlyFinances: cloneFinances(data.yearlyFinances),
+    money: data.money,
+    weeklySponsorship: data.weeklySponsorship,
+    fanHappiness: data.fanHappiness,
+    seasonPointsPerWeek: data.seasonPointsPerWeek,
+    weeklyNews
+  }) as Team;
+
+  team.players = data.players.map((player) => {
+    const revived = revivePlayer(player, team);
+    playerMap.set(player.id, revived);
+    return revived;
+  });
+
+  team.playersToBuy = data.playersToBuy.map((player) => {
+    const revived = revivePlayer(player, null);
+    playerMap.set(player.id, revived);
+    return revived;
+  });
+
+  return team;
+}
+
+function reviveDivision(
+  data: SerializedDivision,
+  teamMap: Map<string, Team>,
+  playerMap: Map<string, Player>,
+  matchIdMap: Map<string, Match>
+): Division {
+  const teams = data.teamIds.map((teamId) => {
+    const team = teamMap.get(teamId);
+    if (!team) {
+      throw new Error('Unable to revive division because a team is missing.');
+    }
+    return team;
+  });
+
+  const division = Object.assign(Object.create(Division.prototype), {
+    name: data.name,
+    level: data.level,
+    teams,
+    matches: [] as Match[][],
+    playable: data.playable
+  }) as Division;
+
+  division.matches = data.matches.map((week) =>
+    week.map((match) => reviveMatch(match, teamMap, playerMap, matchIdMap))
+  );
+
+  division.teams.forEach((team) => {
+    team.division = division;
+  });
+
+  return division;
+}
+
+function reviveManager(data: SerializedManager, teamMap: Map<string, Team>): Manager {
+  const manager = Object.assign(Object.create(Manager.prototype), {
+    name: data.name,
+    team: data.teamId ? teamMap.get(data.teamId) ?? null : null,
+    human: data.human,
+    yearlyStats: data.yearlyStats.map((stats) => ({ ...stats }))
+  }) as Manager;
+  if (manager.team) {
+    manager.team.manager = manager;
+  }
+  return manager;
+}
+
+function reviveGame(serialized: SerializedGame): RehydratedState {
+  const teamMap = new Map<string, Team>();
+  const playerMap = new Map<string, Player>();
+
+  serialized.teams.forEach((team) => {
+    teamMap.set(team.id, reviveTeam(team, playerMap));
+  });
+
+  const matchIdMap = new Map<string, Match>();
+  const divisions = serialized.divisions.map((division) =>
+    reviveDivision(division, teamMap, playerMap, matchIdMap)
+  );
+
+  const game = Object.assign(Object.create(Game.prototype), {
+    name: serialized.name,
+    week: serialized.week,
+    season: serialized.season,
+    divisions,
+    humanTeams: serialized.humanTeamIds
+      .map((id) => teamMap.get(id))
+      .filter((team): team is Team => Boolean(team)),
+    managers: [] as Manager[],
+    lastScreen: serialized.lastScreen,
+    ended: serialized.ended
+  }) as Game;
+
+  const managers = serialized.managers.map((manager) => reviveManager(manager, teamMap));
+  game.managers = managers;
+
+  return { game, matchMap: matchIdMap, teamMap, playerMap };
+}
+
+function serializeMatchRef(
+  match: Match | null,
+  game: Game | null,
+  teamIdMap: Map<Team, string>,
+  playerIdMap: Map<Player, string>
+): SerializedMatchRef {
+  if (!match || !game) {
+    return { id: null, snapshot: null };
+  }
+
+  let matchId: string | null = null;
+  outer: for (let divisionIndex = 0; divisionIndex < game.divisions.length; divisionIndex += 1) {
+    const division = game.divisions[divisionIndex];
+    for (let weekIndex = 0; weekIndex < division.matches.length; weekIndex += 1) {
+      const week = division.matches[weekIndex];
+      for (let matchIndex = 0; matchIndex < week.length; matchIndex += 1) {
+        if (week[matchIndex] === match) {
+          matchId = `${divisionIndex}-${weekIndex}-${matchIndex}`;
+          break outer;
+        }
+      }
+    }
+  }
+
+  const ensureTeam = (team: Team): string => {
+    const id = teamIdMap.get(team);
+    if (!id) {
+      throw new Error('Team missing in serialization map.');
+    }
+    return id;
+  };
+
+  return {
+    id: matchId,
+    snapshot: serializeMatch(match, ensureTeam, teamIdMap, playerIdMap, matchId)
+  };
+}
+
+export function persistGameState({
+  game,
+  currentMatch,
+  liveMatch,
+  selectedTab,
+  weekNews,
+  matchTimeline,
+  isMatchLive,
+  autoPlaying,
+  postMatchSummary
+}: PersistInput): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (!game) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+
+  const { serialized, teamIdMap, playerIdMap } = serializeGame(game);
+
+  const currentMatchRef = serializeMatchRef(currentMatch, game, teamIdMap, playerIdMap);
+  const liveMatchRef = serializeMatchRef(liveMatch, game, teamIdMap, playerIdMap);
+
+  const payload: PersistedPayload = {
+    game: serialized,
+    currentMatch: currentMatchRef,
+    liveMatch: liveMatchRef,
+    selectedTab,
+    weekNews,
+    matchTimeline,
+    isMatchLive,
+    autoPlaying,
+    postMatchSummary
+  };
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+function resolveMatchFromRef(
+  ref: SerializedMatchRef,
+  state: RehydratedState
+): Match | null {
+  const { matchMap, teamMap, playerMap } = state;
+  if (ref.id) {
+    const existing = matchMap.get(ref.id);
+    if (existing) {
+      if (ref.snapshot) {
+        existing.minutes = ref.snapshot.minutes;
+        existing.score = [ref.snapshot.score[0], ref.snapshot.score[1]];
+        existing.possession = [ref.snapshot.possession[0], ref.snapshot.possession[1]];
+        existing.possessionLast5Minutes = [...ref.snapshot.possessionLast5Minutes];
+        existing.tacticalChanges = [ref.snapshot.tacticalChanges[0], ref.snapshot.tacticalChanges[1]];
+        existing.finished = ref.snapshot.finished;
+        existing.substitutions = [ref.snapshot.substitutions[0], ref.snapshot.substitutions[1]];
+        existing.goalscorers = ref.snapshot.goalscorers.map((goal) => ({
+          minute: goal.minute,
+          team: teamMap.get(goal.teamId) ?? existing.teams[0],
+          player: reviveMatchPlayer(goal.player, teamMap, playerMap)
+        }));
+        existing.injuredPlayerOut = ref.snapshot.injuredPlayerOut
+          ? reviveMatchPlayer(ref.snapshot.injuredPlayerOut.player, teamMap, playerMap)
+          : null;
+        existing.isNeutralField = ref.snapshot.isNeutralField;
+      }
+      return existing;
+    }
+  }
+
+  if (!ref.snapshot) {
+    return null;
+  }
+
+  return reviveMatch(ref.snapshot, teamMap, playerMap, state.matchMap);
+}
+
+export function loadGameState(): LoadedState | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(raw) as PersistedPayload;
+    if (!payload.game) {
+      return null;
+    }
+
+    const state = reviveGame(payload.game);
+    const currentMatch = resolveMatchFromRef(payload.currentMatch, state);
+    const liveMatch = resolveMatchFromRef(payload.liveMatch, state);
+
+    return {
+      game: state.game,
+      matchMap: state.matchMap,
+      teamMap: state.teamMap,
+      playerMap: state.playerMap,
+      currentMatch,
+      liveMatch,
+      selectedTab: payload.selectedTab,
+      weekNews: payload.weekNews ?? [],
+      matchTimeline: payload.matchTimeline ?? [],
+      isMatchLive: payload.isMatchLive && Boolean(liveMatch),
+      autoPlaying: false,
+      postMatchSummary: payload.postMatchSummary ?? null
+    };
+  } catch (error) {
+    console.error('Failed to load saved game state', error);
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function clearGameState(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+

--- a/webapp/src/hooks/gamePersistence.ts
+++ b/webapp/src/hooks/gamePersistence.ts
@@ -12,7 +12,7 @@ import {
 } from '@/game';
 import { News, NewsList, type NewsCategory } from '@/game/news';
 import type { Finances, LeagueStats } from '@/game/team';
-import type { MatchEvent, TabKey } from './useGameEngine';
+import type { MatchEvent, StoredMatchPopup, TabKey } from './useGameEngine';
 import type { PostMatchSummary } from './postMatchSummary';
 
 const STORAGE_KEY = 'simplefm:career-state';
@@ -133,6 +133,7 @@ interface PersistedPayload {
   isMatchLive: boolean;
   autoPlaying: boolean;
   postMatchSummary: PostMatchSummary | null;
+  matchPopup: StoredMatchPopup | null;
 }
 
 interface PersistInput {
@@ -145,6 +146,7 @@ interface PersistInput {
   isMatchLive: boolean;
   autoPlaying: boolean;
   postMatchSummary: PostMatchSummary | null;
+  matchPopup: StoredMatchPopup | null;
 }
 
 interface RehydratedState {
@@ -167,6 +169,7 @@ interface LoadedState {
   isMatchLive: boolean;
   autoPlaying: boolean;
   postMatchSummary: PostMatchSummary | null;
+  matchPopup: StoredMatchPopup | null;
 }
 
 function cloneLeagueStats(stats: LeagueStats): LeagueStats {
@@ -657,7 +660,8 @@ export function persistGameState({
     matchTimeline,
     isMatchLive,
     autoPlaying,
-    postMatchSummary
+    postMatchSummary,
+    matchPopup
   };
 
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
@@ -732,7 +736,8 @@ export function loadGameState(): LoadedState | null {
       matchTimeline: payload.matchTimeline ?? [],
       isMatchLive: payload.isMatchLive && Boolean(liveMatch),
       autoPlaying: false,
-      postMatchSummary: payload.postMatchSummary ?? null
+      postMatchSummary: payload.postMatchSummary ?? null,
+      matchPopup: payload.matchPopup ?? null
     };
   } catch (error) {
     console.error('Failed to load saved game state', error);

--- a/webapp/src/hooks/useGameEngine.ts
+++ b/webapp/src/hooks/useGameEngine.ts
@@ -4,14 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { COMPETITION, Game, Match, Player, TEAMS } from '@/game';
 import { createPostMatchSummary, type PostMatchSummary } from './postMatchSummary';
 
-export type TabKey =
-  | 'team'
-  | 'match'
-  | 'league'
-  | 'finance'
-  | 'news'
-  | 'transfers'
-  | 'training';
+export type TabKey = 'team' | 'training' | 'transfers' | 'info' | 'league';
 
 export interface MatchEvent {
   minute: number;

--- a/webapp/src/utils/ratings.ts
+++ b/webapp/src/utils/ratings.ts
@@ -1,0 +1,13 @@
+export function displayRating(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  const rounded = Math.round(value);
+  if (rounded < 1) {
+    return 1;
+  }
+  if (rounded > 20) {
+    return 20;
+  }
+  return rounded;
+}

--- a/webapp/src/utils/training.ts
+++ b/webapp/src/utils/training.ts
@@ -1,0 +1,41 @@
+import type { TrainingDelta } from '@/game/helpers';
+
+type Indicator = TrainingDelta | '';
+type IndicatorToken = TrainingDelta | '·';
+
+const iconMap: Record<IndicatorToken, string> = {
+  '++': '▲▲',
+  '+': '▲',
+  '-': '▼',
+  '--': '▼▼',
+  '·': '·'
+};
+
+const colorMap: Record<IndicatorToken, string> = {
+  '++': 'text-emerald-700',
+  '+': 'text-emerald-600',
+  '-': 'text-amber-600',
+  '--': 'text-red-600',
+  '·': 'text-black/60'
+};
+
+const descriptionMap: Record<IndicatorToken, string> = {
+  '++': 'Major improvement',
+  '+': 'Improving',
+  '-': 'Declining',
+  '--': 'Major decline',
+  '·': 'No change'
+};
+
+export function getTrainingIndicator(delta: Indicator): {
+  icon: string;
+  className: string;
+  description: string;
+} {
+  const token: IndicatorToken = delta === '' ? '·' : delta;
+  return {
+    icon: iconMap[token],
+    className: colorMap[token],
+    description: descriptionMap[token]
+  };
+}

--- a/webapp/src/utils/training.ts
+++ b/webapp/src/utils/training.ts
@@ -1,7 +1,7 @@
 import type { TrainingDelta } from '@/game/helpers';
 
-type Indicator = TrainingDelta | '';
-type IndicatorToken = TrainingDelta | '·';
+type Indicator = TrainingDelta;
+type IndicatorToken = Exclude<TrainingDelta, ''> | '·';
 
 const iconMap: Record<IndicatorToken, string> = {
   '++': '▲▲',

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -30,6 +30,12 @@
       ],
       "@/hooks/*": [
         "src/hooks/*"
+      ],
+      "@/utils": [
+        "src/utils"
+      ],
+      "@/utils/*": [
+        "src/utils/*"
       ]
     },
     "types": [


### PR DESCRIPTION
## Summary
- recreate the start menu, new game form and main navigation to mirror the original Kivy flow
- restyle the match centre, squad, transfers and information screens with Kivy-inspired components and layout
- add a player-focused documentation set plus a tutorial README describing the weekly gameplay loop
- replace the landing page background image with layered CSS gradients so the UI avoids binary assets

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4b8effdc48330a78ba89d1554935c