### PR TITLE
Remove dashboard continue week control

### DIFF
--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -14,7 +14,6 @@ export default function HomePage() {
     availableTeams,
     startNewGame,
     resetGame,
-    advanceWeekWithoutMatch,
     currentMatch,
     leagueTable,
     selectedTab,
@@ -85,7 +84,6 @@ export default function HomePage() {
           weekNews={weekNews}
           selectedTab={selectedTab}
           setSelectedTab={setSelectedTab}
-          onSimulateWeek={advanceWeekWithoutMatch}
           allowedTactics={allowedTactics}
           currentTactic={currentTactic}
           onSetTactic={setHumanTactic}

--- a/webapp/src/components/GameDashboard.tsx
+++ b/webapp/src/components/GameDashboard.tsx
@@ -28,7 +28,6 @@ interface Props {
   weekNews: string[];
   selectedTab: TabKey;
   setSelectedTab: (tab: TabKey) => void;
-  onSimulateWeek: () => void;
   allowedTactics: number[][];
   currentTactic: number[];
   onSetTactic: (tactic: number[]) => OperationResult;
@@ -68,7 +67,6 @@ export function GameDashboard({
   weekNews,
   selectedTab,
   setSelectedTab,
-  onSimulateWeek,
   allowedTactics,
   currentTactic,
   onSetTactic,
@@ -209,11 +207,6 @@ export function GameDashboard({
           Maintain an average of {humanTeam.seasonPointsPerWeek.toFixed(2)} points per week. Stay above position{' '}
           {humanTeam.minPosPerSeasonPointsPerWeek()} to keep the board satisfied.
         </p>
-        <div className="mt-4 flex flex-wrap justify-end gap-3">
-          <button type="button" className="kivy-button" onClick={onSimulateWeek}>
-            Continue week
-          </button>
-        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the Board Expectations "Continue week" control from the career dashboard
- stop passing the unused advanceWeekWithoutMatch callback to the dashboard component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d50b9bbe148330b55e682950e6e580