### PR TITLE
Recreate start and new game menus

### DIFF
--- a/webapp/app/globals.css
+++ b/webapp/app/globals.css
@@ -12,13 +12,15 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: #052314;
+  background-color: #010101;
   background-image:
-    radial-gradient(140% 100% at 15% 0%, rgba(18, 102, 55, 0.9) 0%, rgba(5, 35, 20, 0.5) 45%, rgba(1, 12, 6, 0.9) 100%),
-    radial-gradient(160% 120% at 85% 15%, rgba(11, 54, 30, 0.85) 0%, rgba(2, 17, 9, 0.65) 35%, rgba(1, 8, 4, 0.92) 100%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.02) 0%, rgba(255, 255, 255, 0.02) 45%, transparent 45%, transparent 55%, rgba(255, 255, 255, 0.02) 55%, rgba(255, 255, 255, 0.02) 100%);
-  background-blend-mode: screen, lighten, normal;
-  background-size: cover, cover, 140px 140px;
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.08) 0%, rgba(0, 0, 0, 0) 45%),
+    radial-gradient(circle at 80% 15%, rgba(255, 204, 0, 0.12) 0%, rgba(0, 0, 0, 0) 40%),
+    radial-gradient(circle at 50% 80%, rgba(46, 104, 72, 0.25) 0%, rgba(0, 0, 0, 0.1) 45%),
+    linear-gradient(180deg, rgba(2, 46, 19, 0.95) 0%, rgba(0, 0, 0, 0.92) 100%);
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: cover;
   background-attachment: fixed;
   color: inherit;
 }
@@ -113,4 +115,226 @@ main {
 .kivy-scroll::-webkit-scrollbar-thumb {
   background: rgba(0, 0, 0, 0.25);
   border-radius: 9999px;
+}
+
+.kivy-start-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.kivy-start-screen {
+  width: min(420px, 92vw);
+  height: min(520px, 80vh);
+  display: grid;
+  grid-template-rows: 4fr 2fr 0.5fr 2fr 1.5fr;
+  padding: 20px;
+  gap: 0;
+}
+
+.kivy-start-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(28px, 5vw, 36px);
+  color: #ffffff;
+  text-align: center;
+  font-weight: 600;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.85);
+}
+
+.kivy-start-button {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(18px, 3.6vw, 22px);
+  font-weight: 600;
+  border-radius: 8px;
+  border: 2px solid rgba(0, 0, 0, 0.65);
+  background: linear-gradient(180deg, #f1f1f1 0%, #c7c7c7 100%);
+  color: #1a1a1a;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
+  text-transform: none;
+}
+
+.kivy-start-button:focus-visible,
+.kivy-action-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+.kivy-start-button:active {
+  transform: translateY(1px);
+}
+
+.kivy-new-game-form {
+  width: min(860px, 96vw);
+}
+
+.kivy-new-game-panel {
+  display: flex;
+  flex-direction: column;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 1px;
+  border: 2px solid rgba(0, 0, 0, 0.7);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.6);
+  width: 100%;
+}
+
+.kivy-main-header {
+  background: #1a1a1a;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  min-height: 72px;
+  padding: 0 20px;
+  text-align: center;
+}
+
+.kivy-form-row {
+  display: flex;
+  min-height: 72px;
+  background: rgba(234, 234, 234, 0.95);
+}
+
+.kivy-light-header {
+  flex: 0 0 25%;
+  background: #333333;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.kivy-field {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+}
+
+.kivy-input,
+.kivy-select {
+  width: 100%;
+  font-size: 1rem;
+  padding: 12px 14px;
+  border: 2px solid rgba(0, 0, 0, 0.65);
+  border-radius: 6px;
+  background: linear-gradient(180deg, #fafafa 0%, #d7d7d7 100%);
+  color: #1a1a1a;
+  font-weight: 600;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.12);
+}
+
+.kivy-input::placeholder {
+  color: rgba(26, 26, 26, 0.6);
+}
+
+.kivy-select {
+  cursor: pointer;
+}
+
+.kivy-input:focus,
+.kivy-select:focus {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 1px;
+}
+
+.kivy-subpanel {
+  background: rgba(0, 0, 0, 0.35);
+  padding: 1px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.kivy-subpanel .kivy-form-row {
+  background: rgba(234, 234, 234, 0.96);
+}
+
+.kivy-section-header {
+  background: #333333;
+  color: #ffffff;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 0 20px;
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+}
+
+.kivy-form-row--split .kivy-light-header {
+  flex: 0 0 12%;
+}
+
+.kivy-form-row--split .kivy-field {
+  flex: 1;
+}
+
+.kivy-error {
+  background: rgba(128, 0, 0, 0.85);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 14px 20px;
+  font-size: 0.95rem;
+}
+
+.kivy-form-spacer {
+  min-height: 48px;
+  background: transparent;
+}
+
+.kivy-form-footer {
+  display: flex;
+  gap: 10px;
+  padding: 16px 20px 20px;
+  background: rgba(234, 234, 234, 0.95);
+  align-items: stretch;
+}
+
+.kivy-action-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 10px;
+  border: 2px solid rgba(0, 0, 0, 0.7);
+  background: linear-gradient(180deg, #f4f4f4 0%, #c6c6c6 100%);
+  color: #1a1a1a;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 16px 12px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.kivy-action-button svg {
+  width: 50px;
+  height: 50px;
+}
+
+.kivy-action-button span {
+  font-size: 0.9rem;
+}
+
+.kivy-action-button:active {
+  transform: translateY(1px);
+}
+
+.kivy-action-button--back {
+  flex: 0.25;
+}
+
+.kivy-action-button--primary {
+  flex: 0.75;
 }

--- a/webapp/src/components/NewGameForm.tsx
+++ b/webapp/src/components/NewGameForm.tsx
@@ -1,8 +1,66 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type SVGProps } from 'react';
 import { COLORS, COMPETITION, COUNTRIES } from '@/game';
 import type { NewGamePayload } from '@/hooks/useGameEngine';
+
+const DEFAULT_TEAM_OPTION = 'Create new team';
+
+function BackIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false" {...props}>
+      <rect x="6" y="6" width="52" height="52" rx="8" fill="#f0f0f0" stroke="#1f1f1f" strokeWidth="4" />
+      <path
+        d="M30 19 16 32l14 13"
+        fill="none"
+        stroke="#1f1f1f"
+        strokeWidth="6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M32 32h16"
+        fill="none"
+        stroke="#1f1f1f"
+        strokeWidth="6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false" {...props}>
+      <rect x="6" y="6" width="52" height="52" rx="12" fill="#d1eacd" stroke="#1f1f1f" strokeWidth="4" />
+      <path
+        d="M22 34.5 30.5 43 46 25"
+        fill="none"
+        stroke="#1f1f1f"
+        strokeWidth="6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function getContrastColor(hexColor: string) {
+  const sanitized = hexColor.replace('#', '');
+  const expanded =
+    sanitized.length === 3
+      ? sanitized
+          .split('')
+          .map((char) => `${char}${char}`)
+          .join('')
+      : sanitized;
+  const red = parseInt(expanded.slice(0, 2), 16);
+  const green = parseInt(expanded.slice(2, 4), 16);
+  const blue = parseInt(expanded.slice(4, 6), 16);
+  const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
+  return luminance > 180 ? '#111111' : '#f6f6f6';
+}
 
 interface Props {
   availableTeams: string[];
@@ -11,11 +69,11 @@ interface Props {
 }
 
 export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
-  const teamOptions = useMemo(() => ['Create new team', ...availableTeams], [availableTeams]);
+  const teamOptions = useMemo(() => [DEFAULT_TEAM_OPTION, ...availableTeams], [availableTeams]);
 
   const [gameName, setGameName] = useState('');
   const [managerName, setManagerName] = useState('');
-  const [selectedTeam, setSelectedTeam] = useState<string>('Create new team');
+  const [selectedTeam, setSelectedTeam] = useState<string>(DEFAULT_TEAM_OPTION);
   const [customName, setCustomName] = useState('');
   const [customCountry, setCustomCountry] = useState<string>(COUNTRIES[0]?.id ?? 'Eng');
   const [customColor, setCustomColor] = useState<string>(COLORS[0]?.hex ?? '#485C96');
@@ -24,7 +82,8 @@ export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
   const [customPosition, setCustomPosition] = useState(1);
   const [error, setError] = useState<string | null>(null);
 
-  const useCustomTeam = selectedTeam === 'Create new team';
+  const useCustomTeam = selectedTeam === DEFAULT_TEAM_OPTION;
+  const customColorText = useMemo(() => getContrastColor(customColor), [customColor]);
 
   const resetError = () => setError(null);
 
@@ -69,78 +128,111 @@ export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
   };
 
   return (
-    <form onSubmit={submit} className="kivy-panel w-full max-w-4xl overflow-hidden">
-      <header className="kivy-header px-6 py-4 text-center text-lg font-semibold uppercase tracking-[0.35em]">
-        New Game
-      </header>
-      <div className="space-y-6 px-6 py-6">
-        <div className="grid gap-3 sm:grid-cols-[0.85fr_1.15fr] sm:items-center">
-          <label className="text-sm font-semibold uppercase tracking-wide">Game name</label>
-          <input
-            value={gameName}
-            onChange={(event) => {
-              resetError();
-              setGameName(event.target.value);
-            }}
-            placeholder="Max 16 characters"
-            maxLength={16}
-            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
-          />
+    <form onSubmit={submit} className="kivy-new-game-form" aria-label="New game form">
+      <div className="kivy-new-game-panel">
+        <header className="kivy-main-header">New Game</header>
+
+        <div className="kivy-form-row">
+          <div className="kivy-light-header">Game name</div>
+          <div className="kivy-field">
+            <input
+              value={gameName}
+              onChange={(event) => {
+                resetError();
+                setGameName(event.target.value);
+              }}
+              placeholder="Max 16 char, only letters and numbers"
+              maxLength={16}
+              className="kivy-input"
+            />
+          </div>
         </div>
-        <div className="grid gap-3 sm:grid-cols-[0.85fr_1.15fr] sm:items-center">
-          <label className="text-sm font-semibold uppercase tracking-wide">Manager name</label>
-          <input
-            value={managerName}
-            onChange={(event) => {
-              resetError();
-              setManagerName(event.target.value);
-            }}
-            placeholder="Max 16 characters"
-            maxLength={16}
-            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
-          />
+
+        <div className="kivy-form-row">
+          <div className="kivy-light-header">Manager name</div>
+          <div className="kivy-field">
+            <input
+              value={managerName}
+              onChange={(event) => {
+                resetError();
+                setManagerName(event.target.value);
+              }}
+              placeholder="Max 16 char, only letters and numbers"
+              maxLength={16}
+              className="kivy-input"
+            />
+          </div>
         </div>
-        <div className="grid gap-3 sm:grid-cols-[0.85fr_1.15fr] sm:items-center">
-          <label className="text-sm font-semibold uppercase tracking-wide">Team</label>
-          <select
-            value={selectedTeam}
-            onChange={(event) => {
-              setSelectedTeam(event.target.value);
-              resetError();
-            }}
-            className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
-          >
-            {teamOptions.map((team) => (
-              <option key={team} value={team}>
-                {team}
-              </option>
-            ))}
-          </select>
+
+        <div className="kivy-form-row">
+          <div className="kivy-light-header">Team</div>
+          <div className="kivy-field">
+            <select
+              value={selectedTeam}
+              onChange={(event) => {
+                setSelectedTeam(event.target.value);
+                resetError();
+              }}
+              className="kivy-select"
+            >
+              {teamOptions.map((team) => (
+                <option key={team} value={team}>
+                  {team}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {useCustomTeam && (
-          <div className="rounded-2xl border-2 border-black/10 bg-white/90 p-4">
-            <h3 className="text-base font-semibold uppercase tracking-wide">Create new team</h3>
-            <div className="mt-4 grid gap-4 sm:grid-cols-2">
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-semibold uppercase tracking-wide">Name</span>
+          <div className="kivy-subpanel" aria-label="Create new team fields">
+            <div className="kivy-form-row">
+              <div className="kivy-light-header">Name</div>
+              <div className="kivy-field">
                 <input
                   value={customName}
                   onChange={(event) => {
                     setCustomName(event.target.value);
                     resetError();
                   }}
-                  placeholder="Max 16 characters"
+                  placeholder="Max 16 char, only letters and numbers"
                   maxLength={16}
-                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                  className="kivy-input"
                 />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-semibold uppercase tracking-wide">Country</span>
+              </div>
+            </div>
+
+            <div className="kivy-form-row">
+              <div className="kivy-light-header">Color</div>
+              <div className="kivy-field">
+                <select
+                  value={customColorName}
+                  onChange={(event) => {
+                    const color = COLORS.find((entry) => entry.name === event.target.value);
+                    if (color) {
+                      setCustomColor(color.hex);
+                      setCustomColorName(color.name);
+                    }
+                  }}
+                  className="kivy-select"
+                  style={{ background: customColor, color: customColorText }}
+                >
+                  {COLORS.map((color) => (
+                    <option key={color.name} value={color.name}>
+                      {color.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="kivy-form-row">
+              <div className="kivy-light-header">Country</div>
+              <div className="kivy-field">
                 <select
                   value={customCountry}
                   onChange={(event) => setCustomCountry(event.target.value)}
-                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                  className="kivy-select"
                 >
                   {COUNTRIES.map((country) => (
                     <option key={country.id} value={country.id}>
@@ -148,13 +240,18 @@ export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
                     </option>
                   ))}
                 </select>
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-semibold uppercase tracking-wide">Division</span>
+              </div>
+            </div>
+
+            <div className="kivy-section-header">Division and position</div>
+
+            <div className="kivy-form-row kivy-form-row--split">
+              <div className="kivy-light-header">Div</div>
+              <div className="kivy-field">
                 <select
                   value={customDivision}
                   onChange={(event) => setCustomDivision(Number(event.target.value))}
-                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                  className="kivy-select"
                 >
                   {Array.from({ length: COMPETITION['TOTAL_NUMBER_OF_DIVISIONS'] }, (_, index) => index + 1).map((value) => (
                     <option key={value} value={value}>
@@ -162,13 +259,13 @@ export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
                     </option>
                   ))}
                 </select>
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-semibold uppercase tracking-wide">Position</span>
+              </div>
+              <div className="kivy-light-header">Pos</div>
+              <div className="kivy-field">
                 <select
                   value={customPosition}
                   onChange={(event) => setCustomPosition(Number(event.target.value))}
-                  className="rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
+                  className="kivy-select"
                 >
                   {Array.from({ length: COMPETITION['TEAMS PER DIVISION'] }, (_, index) => index + 1).map((value) => (
                     <option key={value} value={value}>
@@ -176,44 +273,26 @@ export function NewGameForm({ availableTeams, onStart, onCancel }: Props) {
                     </option>
                   ))}
                 </select>
-              </label>
-              <label className="flex flex-col gap-1 text-sm sm:col-span-2">
-                <span className="font-semibold uppercase tracking-wide">Team color</span>
-                <div className="flex items-center gap-3">
-                  <div className="h-9 w-9 rounded-full border-2 border-black/15" style={{ background: customColor }} />
-                  <select
-                    value={customColorName}
-                    onChange={(event) => {
-                      const color = COLORS.find((entry) => entry.name === event.target.value);
-                      if (color) {
-                        setCustomColor(color.hex);
-                        setCustomColorName(color.name);
-                      }
-                    }}
-                    className="flex-1 rounded-lg border-2 border-black/15 bg-white px-3 py-2 text-sm"
-                  >
-                    {COLORS.map((color) => (
-                      <option key={color.name} value={color.name}>
-                        {color.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </label>
+              </div>
             </div>
           </div>
         )}
 
-        {error && <p className="text-sm font-semibold text-red-600">{error}</p>}
+        {error && <div className="kivy-error" role="alert">{error}</div>}
+
+        <div className="kivy-form-spacer" aria-hidden="true" />
+
+        <footer className="kivy-form-footer">
+          <button type="button" className="kivy-action-button kivy-action-button--back" onClick={onCancel}>
+            <BackIcon />
+            <span>Back</span>
+          </button>
+          <button type="submit" className="kivy-action-button kivy-action-button--primary">
+            <CheckIcon />
+            <span>Create Game</span>
+          </button>
+        </footer>
       </div>
-      <footer className="kivy-footer flex items-center justify-end gap-3 px-6 py-4">
-        <button type="button" className="kivy-button kivy-button--secondary" onClick={onCancel}>
-          Back
-        </button>
-        <button type="submit" className="kivy-button">
-          Create Game
-        </button>
-      </footer>
     </form>
   );
 }

--- a/webapp/src/components/StartScreen.tsx
+++ b/webapp/src/components/StartScreen.tsx
@@ -7,27 +7,17 @@ interface StartScreenProps {
 
 export function StartScreen({ onNewGame, onLoadGame }: StartScreenProps) {
   return (
-    <div className="flex w-full max-w-xl flex-col items-center gap-8 text-center">
-      <div className="w-full rounded-3xl border-2 border-black/20 bg-black/70 px-10 py-12 shadow-xl">
-        <div className="flex flex-col items-center gap-6">
-          <h1
-            className="text-4xl font-bold tracking-wide text-white"
-            style={{ textShadow: '0 3px 6px rgba(0,0,0,0.6)' }}
-          >
-            Simple FM
-          </h1>
-          <p className="max-w-sm text-sm text-white/80">
-            The original desktop flow recreated for the web. Manage your squad, train your talents and climb the league ladder one week at a time.
-          </p>
-          <div className="flex w-full flex-col gap-3">
-            <button type="button" className="kivy-button" onClick={onNewGame}>
-              New Game
-            </button>
-            <button type="button" className="kivy-button kivy-button--secondary" onClick={onLoadGame}>
-              Load Game
-            </button>
-          </div>
-        </div>
+    <div className="kivy-start-wrapper">
+      <div className="kivy-start-screen" role="menu" aria-label="Start menu">
+        <h1 className="kivy-start-title">Simple FM</h1>
+        <button type="button" className="kivy-start-button" onClick={onNewGame}>
+          New Game
+        </button>
+        <div aria-hidden="true" />
+        <button type="button" className="kivy-start-button" onClick={onLoadGame}>
+          Load Game
+        </button>
+        <div aria-hidden="true" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- port the Kivy start menu into the web StartScreen with the same layout and button behaviour as the desktop version
- rebuild the NewGameForm to mirror the original new game and team selection flow, including the custom team section and icon buttons
- add the shared background and supporting styles/assets so the web UI matches the Kivy palette and spacing
- replace raster background and button icons with CSS gradients and inline SVGs so no binary assets are required

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d51e10e38c833095968ce51305e02d