### PR TITLE
Add Textual terminal UI for SimpleFM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sh==2.0.6
 urllib3==2.1.0
 virtualenv==20.25.0
 sentry-sdk==2.13.0
+textual==0.47.1

--- a/tests/test_tui_state.py
+++ b/tests/test_tui_state.py
@@ -1,0 +1,63 @@
+import shutil
+import tempfile
+import unittest
+
+from tui.state import SimpleFMState
+
+
+class TestTUIState(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp()
+        self.state = SimpleFMState(save_dir=self.temp_dir)
+        team_name = self.state.list_selectable_teams()[0]["name"]
+        self.state.start_new_game(
+            game_name="TestCareer",
+            manager_name="Alex",
+            team_name=team_name,
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_header_context(self) -> None:
+        header = self.state.header_context()
+        self.assertIn("team", header)
+        self.assertEqual(header["manager"], "Alex")
+
+    def test_tactic_and_swap(self) -> None:
+        options = self.state.tactic_options()
+        self.assertTrue(options)
+        self.state.set_tactic(options[0])
+        overview = self.state.team_overview()
+        starting = overview["starting"][0]
+        bench = overview["bench"][0]
+        swapped = self.state.swap_players(starting.identifier, bench.identifier)
+        self.assertTrue(swapped)
+
+    def test_transfers_and_week_progress(self) -> None:
+        initial_players = len(self.state.squad_for_transfers())
+        targets = self.state.transfer_targets()
+        self.assertTrue(targets)
+        target_id = targets[0].identifier
+        self.state.buy_player(target_id)
+        self.assertGreater(len(self.state.squad_for_transfers()), initial_players)
+
+        # sell a player without a contract to validate the flow
+        for player in self.state.squad_for_transfers():
+            if player.contract == 0 and not player.injured and player.position != "GK":
+                self.state.sell_player(player.identifier)
+                break
+
+        summary = self.state.continue_week()
+        self.assertIn("finances", summary)
+        self.assertIn("news", summary)
+
+    def test_manager_stats(self) -> None:
+        stats = self.state.manager_stats()
+        self.assertEqual(stats["name"], "Alex")
+        self.assertIn("career", stats)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tui/__init__.py
+++ b/tui/__init__.py
@@ -1,0 +1,13 @@
+"""Terminal user interface for Simple Football Manager.
+
+This package exposes a rich Textual-based interface that mirrors the
+functionality of the original Kivy GUI while embracing a retro inspired
+terminal presentation.  The public entry point is :mod:`tui.app`.
+"""
+
+from __future__ import annotations
+
+__all__ = ["SimpleFMTUI"]
+
+from .app import SimpleFMTUI
+

--- a/tui/app.py
+++ b/tui/app.py
@@ -1,0 +1,66 @@
+"""Application entry-point for the SimpleFM Textual UI."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from textual.app import App
+from textual.binding import Binding
+
+from .state import SimpleFMState
+from .screens import (
+    LoadGameScreen,
+    MainScreen,
+    ManagerStatsScreen,
+    MatchScreen,
+    NewGameScreen,
+    StartScreen,
+    SummaryScreen,
+)
+
+
+class SimpleFMTUI(App):
+    """Main Textual application orchestrating all screens."""
+
+    CSS_PATH = "tui/styles.css"
+    BINDINGS = [
+        Binding("ctrl+s", "save", "Save"),
+        Binding("ctrl+q", "quit", "Quit"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.state = SimpleFMState()
+
+    def on_mount(self) -> None:  # pragma: no cover - UI bootstrapping
+        self.push_screen(StartScreen())
+
+    def action_save(self) -> None:  # pragma: no cover - save shortcut
+        try:
+            self.state.save_game()
+            self.notify("Game saved", severity="information")
+        except Exception as exc:
+            self.notify(f"Unable to save: {exc}", severity="error")
+
+    # ------------------------------------------------------------------
+    # Routing helpers used by the individual screens
+    # ------------------------------------------------------------------
+
+    def show_new_game(self) -> None:  # pragma: no cover - UI routing
+        self.push_screen(NewGameScreen())
+
+    def show_load_game(self) -> None:  # pragma: no cover - UI routing
+        self.push_screen(LoadGameScreen())
+
+    def show_main(self) -> None:  # pragma: no cover - UI routing
+        self.push_screen(MainScreen())
+
+    def show_match(self) -> None:  # pragma: no cover - UI routing
+        self.push_screen(MatchScreen())
+
+    def show_summary(self, summary: Dict[str, object]) -> None:  # pragma: no cover
+        self.push_screen(SummaryScreen(summary))
+
+    def show_manager_stats(self) -> None:  # pragma: no cover
+        self.push_screen(ManagerStatsScreen())
+

--- a/tui/formatters.py
+++ b/tui/formatters.py
@@ -1,0 +1,78 @@
+"""Utility formatting helpers for the SimpleFM terminal UI."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+def money_to_str(number: float) -> str:
+    """Return a compact string for a monetary value.
+
+    The original Kivy implementation shows numbers in thousands (``k``)
+    and millions (``M``).  We port the same formatting rules here so the
+    TUI matches the expectations from the classic interface.
+    """
+
+    if number == 0:
+        sign = 1
+    else:
+        sign = int(number / abs(number))
+
+    number = int(round(abs(number), 1))
+    thousands = number / 1000
+
+    if thousands >= 1:
+        if thousands >= 10:
+            if thousands >= 1000:
+                if thousands >= 10000:
+                    return f"{int(round(sign * thousands / 1000.0, 1))}M"
+                return f"{round(sign * thousands / 1000.0, 1)}M"
+            return f"{int(round(sign * thousands, 0))}k"
+        return f"{int(round(sign * number / 1000, 0))}k"
+    return f"{int(round(sign * number, 0))}"
+
+
+def tactic_to_str(tactic: Sequence[int]) -> str:
+    """Represent a tactic array (e.g. ``[4, 4, 2]``) as ``"4-4-2"``."""
+
+    return "-".join(str(part) for part in tactic)
+
+
+def table_position_to_str(number: int) -> str:
+    """Return the ordinal representation used throughout the UI."""
+
+    suffix = "th"
+    if number % 100 not in {11, 12, 13}:
+        if number % 10 == 1:
+            suffix = "st"
+        elif number % 10 == 2:
+            suffix = "nd"
+        elif number % 10 == 3:
+            suffix = "rd"
+    return f"{number}{suffix}"
+
+
+def training_to_str(training: float) -> str:
+    """Translate a raw training delta into the symbolic arrows."""
+
+    if training >= 0.03:
+        return "++"
+    if training >= 0.015:
+        return "+"
+    if training <= -0.03:
+        return "--"
+    if training <= -0.015:
+        return "-"
+    return ""
+
+
+def join_names(items: Iterable[str]) -> str:
+    """Join a series of names using commas and ``and`` like the popups."""
+
+    names = list(items)
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+    return ", ".join(names[:-1]) + f" and {names[-1]}"
+

--- a/tui/screens/__init__.py
+++ b/tui/screens/__init__.py
@@ -1,0 +1,20 @@
+"""Screen exports for the SimpleFM Textual UI."""
+
+from .start import StartScreen
+from .new_game import NewGameScreen
+from .load_game import LoadGameScreen
+from .main import MainScreen
+from .match import MatchScreen
+from .summary import SummaryScreen
+from .manager import ManagerStatsScreen
+
+__all__ = [
+    "StartScreen",
+    "NewGameScreen",
+    "LoadGameScreen",
+    "MainScreen",
+    "MatchScreen",
+    "SummaryScreen",
+    "ManagerStatsScreen",
+]
+

--- a/tui/screens/base.py
+++ b/tui/screens/base.py
@@ -1,0 +1,19 @@
+"""Base helpers shared across screens."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.screen import Screen
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from ..app import SimpleFMTUI
+
+
+class StateScreen(Screen):
+    """Screen with a strongly typed reference to the application."""
+
+    @property
+    def app(self) -> "SimpleFMTUI":  # type: ignore[override]
+        return super().app  # type: ignore[return-value]
+

--- a/tui/screens/load_game.py
+++ b/tui/screens/load_game.py
@@ -1,0 +1,62 @@
+"""Screen to select and load an existing save file."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
+
+from .base import StateScreen
+
+
+class LoadGameScreen(StateScreen):
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="load-layout"):
+            yield Static("[bold]Choose a saved career[/bold]", id="load-title")
+            yield ListView(id="games-list")
+            yield Button("Load", id="load", variant="success")
+            yield Button("Back", id="back", variant="warning")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.refresh_games()
+
+    def refresh_games(self) -> None:
+        list_view = self.query_one("#games-list", ListView)
+        list_view.clear()
+        self._games = self.app.state.list_saved_games()
+
+        if not self._games:
+            list_view.append(ListItem(Static("No saved games found."), disabled=True))
+        else:
+            for name in self._games:
+                list_view.append(ListItem(Static(name)))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "load":
+            self._load_selected()
+        elif event.button.id == "back":
+            self.app.pop_screen()
+
+    def _load_selected(self) -> None:
+        list_view = self.query_one("#games-list", ListView)
+        if not getattr(self, "_games", None):
+            self.app.notify("No saved games to load", severity="warning")
+            return
+
+        index = list_view.index
+        if index is None or index < 0 or index >= len(self._games):
+            self.app.notify("Select a save first", severity="warning")
+            return
+
+        name = self._games[index]
+        try:
+            self.app.state.load_game(name)
+        except Exception as exc:
+            self.app.notify(str(exc), severity="error")
+            return
+
+        self.app.notify(f"Loaded {name}", severity="information")
+        self.app.show_main()
+

--- a/tui/screens/main.py
+++ b/tui/screens/main.py
@@ -1,0 +1,428 @@
+"""Main in-game dashboard hosting all management views."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Type
+
+from rich.table import Table
+
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.reactive import reactive
+from textual.widgets import Button, DataTable, Footer, Header, ListItem, ListView, Select, Static
+
+from ..formatters import money_to_str, tactic_to_str, table_position_to_str, training_to_str
+from ..state import PlayerSummary
+from .base import StateScreen
+
+
+NAVIGATION: Dict[str, str] = {
+    "team": "Team",
+    "training": "Training",
+    "transfers": "Transfers",
+    "info": "Information",
+    "league": "League",
+}
+
+
+class PlayerList(ListView):
+    """Reusable list widget showing players in a section."""
+
+    def set_players(self, players: Iterable[PlayerSummary]) -> None:
+        self.clear()
+        for player in players:
+            flags = []
+            if player.injured:
+                flags.append("inj")
+            if not player.match_available:
+                flags.append("na")
+            if player.skill_change > 0:
+                flags.append("+1")
+            elif player.skill_change < 0:
+                flags.append("-1")
+
+            info = f"{player.position} {player.name} ({player.age})  Skill {player.skill}"
+            if flags:
+                info += "  [" + ", ".join(flags) + "]"
+            item = ListItem(Static(info))
+            setattr(item, "player_id", player.identifier)
+            self.append(item)
+
+
+class MainScreen(StateScreen):
+    active_view = reactive("team")
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="main-layout"):
+            with Horizontal(id="top-bar"):
+                yield Static(id="game-header")
+                yield Button("Manager stats", id="manager-stats", variant="primary")
+            yield Container(id="content")
+            with Horizontal(id="nav"):
+                for view, label in NAVIGATION.items():
+                    yield Button(label, id=f"nav-{view}")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._view_factories: Dict[str, Type[BaseView]] = {
+            "team": TeamView,
+            "training": TrainingView,
+            "transfers": TransfersView,
+            "info": InformationView,
+            "league": LeagueView,
+        }
+        self._current_view: Optional[BaseView] = None
+        self.refresh_header()
+        self.show_view(self.active_view)
+
+    def on_show(self) -> None:
+        self.refresh_header()
+        if self._current_view:
+            self._current_view.refresh()
+
+    def refresh_header(self) -> None:
+        ctx = self.app.state.header_context()
+        header = self.query_one("#game-header", Static)
+        header.update(
+            f"[b]{ctx['team']}[/b] | Manager: {ctx['manager']} | Week {ctx['week']} ({ctx['year']}) | "
+            f"Cash: {ctx['money']} | Fan happiness: {ctx['fan_happiness']}"
+        )
+
+    def show_view(self, view_name: str) -> None:
+        self.active_view = view_name
+        content = self.query_one("#content", Container)
+        for child in list(content.children):
+            child.remove()
+        view_cls = self._view_factories[view_name]
+        view = view_cls(self)
+        content.mount(view)
+        self._current_view = view
+        view.refresh()
+        self._update_nav()
+
+    def watch_active_view(self, _: str) -> None:
+        self._update_nav()
+
+    def _update_nav(self) -> None:
+        for view, label in NAVIGATION.items():
+            button = self.query_one(f"#nav-{view}", Button)
+            button.variant = "success" if view == self.active_view else "default"
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "manager-stats":
+            self.app.show_manager_stats()
+            return
+
+        for view in NAVIGATION:
+            if event.button.id == f"nav-{view}":
+                self.show_view(view)
+                break
+
+
+class BaseView(Vertical):
+    def __init__(self, screen: MainScreen) -> None:
+        super().__init__()
+        self.screen = screen
+
+    @property
+    def app(self):  # pragma: no cover - typing helper
+        return self.screen.app
+
+    def refresh(self) -> None:
+        raise NotImplementedError
+
+
+class TeamView(BaseView):
+    def compose(self) -> ComposeResult:
+        yield Static(id="match-info")
+        yield Select(id="tactic-select")
+        with Horizontal(id="team-lists"):
+            yield Vertical(Static("Starting XI", classes="list-title"), PlayerList(id="list-starting"))
+            yield Vertical(Static("Bench", classes="list-title"), PlayerList(id="list-bench"))
+            yield Vertical(Static("Reserves", classes="list-title"), PlayerList(id="list-reserves"))
+        yield Static("Select two players to swap. Press ENTER on each selection.", id="swap-hint")
+        yield Button("Go to match", id="go-match", variant="primary")
+
+    def on_mount(self) -> None:
+        self.selection: List[int] = []
+        self.refresh()
+
+    def refresh(self) -> None:
+        state = self.app.state
+        team = state.active_team
+        if team is None:
+            return
+        self.selection.clear()
+        overview = state.team_overview()
+        self.query_one("#list-starting", PlayerList).set_players(overview["starting"])
+        self.query_one("#list-bench", PlayerList).set_players(overview["bench"])
+        self.query_one("#list-reserves", PlayerList).set_players(overview["reserves"])
+
+        options = state.tactic_options()
+        select = self.query_one("#tactic-select", Select)
+        option_pairs = [(opt, opt) for opt in options]
+        if hasattr(select, "set_options"):
+            select.set_options(option_pairs)
+        else:  # pragma: no cover - compatibility path
+            select.options = option_pairs  # type: ignore[attr-defined]
+        current = tactic_to_str(team.current_tactic())
+        if current not in options:
+            current = "Top skill"
+        select.value = current
+
+        opponent = state.next_opponent()
+        if opponent:
+            info = (
+                f"Next: [b]{opponent['location']}[/b] vs {opponent['name']}  "
+                f"Skill {opponent['avg_skill']}  Tactic {opponent['tactic']}"
+            )
+        else:
+            info = "No scheduled opponent this week."
+        self.query_one("#match-info", Static).update(info)
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "tactic-select" and event.value:
+            self.app.state.set_tactic(event.value)
+            self.refresh()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        item = event.item
+        player_id = getattr(item, "player_id", None)
+        if player_id is None:
+            return
+        self.selection.append(player_id)
+        if len(self.selection) == 2:
+            self._attempt_swap()
+
+    def _attempt_swap(self) -> None:
+        player_out, player_in = self.selection
+        self.selection.clear()
+        if not self.app.state.swap_players(player_out, player_in):
+            self.app.notify("Swap not allowed", severity="warning")
+            return
+        self.app.notify("Players swapped", severity="information")
+        self.refresh()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "go-match":
+            self.app.show_match()
+
+
+class TrainingView(BaseView):
+    def compose(self) -> ComposeResult:
+        table = DataTable(id="training-table", zebra_stripes=True)
+        table.add_columns("Pos", "Player", "Age", "Skill", "Training")
+        yield table
+
+    def refresh(self) -> None:
+        table = self.query_one("#training-table", DataTable)
+        table.clear(rows=True)
+        report = self.app.state.training_report()
+        for entry in report:
+            player = entry["player"]
+            table.add_row(
+                player.position,
+                player.name,
+                str(player.age),
+                str(player.skill),
+                training_to_str(player.weekly_training),
+            )
+
+
+class TransfersView(BaseView):
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="transfers-layout"):
+            with Vertical(id="transfer-targets"):
+                yield Static("Transfer targets", classes="list-title")
+                yield ListView(id="targets-list")
+                yield Button("Buy player", id="buy", variant="success")
+            with Vertical(id="transfer-squad"):
+                yield Static("Your squad", classes="list-title")
+                yield ListView(id="squad-list")
+                with Horizontal():
+                    yield Button("Sell", id="sell", variant="warning")
+                    yield Button("Renew", id="renew", variant="primary")
+
+    def refresh(self) -> None:
+        state = self.app.state
+        targets = self.query_one("#targets-list", ListView)
+        targets.clear()
+        self._targets = state.transfer_targets()
+        if not self._targets:
+            targets.append(ListItem(Static("No players available."), disabled=True))
+        else:
+            for player in self._targets:
+                text = (
+                    f"{player.position} {player.name} ({player.age}) Skill {player.skill} | "
+                    f"Value {money_to_str(player.value)}"
+                )
+                item = ListItem(Static(text))
+                setattr(item, "player_id", player.identifier)
+                targets.append(item)
+
+        squad = self.query_one("#squad-list", ListView)
+        squad.clear()
+        self._squad = self.app.state.squad_for_transfers()
+        for player in self._squad:
+            contract = "Contract" if player.contract else "No contract"
+            text = (
+                f"{player.position} {player.name} ({player.age}) Skill {player.skill} | "
+                f"Salary {money_to_str(player.salary)} | Value {money_to_str(player.value)} | {contract}"
+            )
+            item = ListItem(Static(text))
+            setattr(item, "player_id", player.identifier)
+            squad.append(item)
+
+    def _selected_target(self) -> Optional[int]:
+        list_view = self.query_one("#targets-list", ListView)
+        index = list_view.index
+        if index is None or not self._targets or index >= len(self._targets):
+            return None
+        return self._targets[index].identifier
+
+    def _selected_squad_player(self) -> Optional[int]:
+        list_view = self.query_one("#squad-list", ListView)
+        index = list_view.index
+        if index is None or not self._squad or index >= len(self._squad):
+            return None
+        return self._squad[index].identifier
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        state = self.app.state
+        if event.button.id == "buy":
+            player_id = self._selected_target()
+            if player_id is None:
+                self.app.notify("Select a transfer target first", severity="warning")
+                return
+            try:
+                state.buy_player(player_id)
+            except Exception as exc:
+                self.app.notify(str(exc), severity="error")
+            else:
+                self.app.notify("Player signed", severity="information")
+            self.refresh()
+        elif event.button.id == "sell":
+            player_id = self._selected_squad_player()
+            if player_id is None:
+                self.app.notify("Select a player to sell", severity="warning")
+                return
+            try:
+                state.sell_player(player_id)
+            except Exception as exc:
+                self.app.notify(str(exc), severity="error")
+            else:
+                self.app.notify("Player sold", severity="information")
+            self.refresh()
+        elif event.button.id == "renew":
+            player_id = self._selected_squad_player()
+            if player_id is None:
+                self.app.notify("Select a player to renew", severity="warning")
+                return
+            try:
+                state.renew_contract(player_id)
+            except Exception as exc:
+                self.app.notify(str(exc), severity="error")
+            else:
+                self.app.notify("Contract renewed", severity="information")
+            self.refresh()
+
+
+class InformationView(BaseView):
+    def compose(self) -> ComposeResult:
+        yield Static(id="finances-table")
+        yield Static("Weekly news", classes="list-title")
+        yield ListView(id="news-list")
+        with Horizontal():
+            yield Button("Continue week", id="continue", variant="success")
+            yield Button("Refresh", id="refresh-info", variant="primary")
+
+    def refresh(self) -> None:
+        data = self.app.state.finances()
+        table = Table(title="Finances", expand=True)
+        table.add_column("Category")
+        table.add_column("Weekly")
+        table.add_column("Season")
+
+        for key, values in data["income"].items():
+            table.add_row(f"Income – {key}", values["weekly"], values["yearly"])
+        table.add_row("Income – Total", data["income_total"], data["income_total_yearly"])
+        for key, values in data["expense"].items():
+            table.add_row(f"Expense – {key}", values["weekly"], values["yearly"])
+        table.add_row("Expense – Total", data["expense_total"], data["expense_total_yearly"])
+        table.add_row("Balance", data["balance_weekly"], data["balance_yearly"])
+        table.add_row("Cash", data["cash"], "")
+        table.add_row("Season goal", str(data["goal"]), "")
+        table.add_row("Fan happiness", str(data["fan_happiness"]), "")
+
+        self.query_one("#finances-table", Static).update(table)
+
+        news_list = self.query_one("#news-list", ListView)
+        news_list.clear()
+        for message in data["news"]:
+            news_list.append(ListItem(Static(message)))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "continue":
+            try:
+                summary = self.app.state.continue_week()
+            except Exception as exc:
+                self.app.notify(str(exc), severity="error")
+                return
+            self.app.show_summary(summary)
+        elif event.button.id == "refresh-info":
+            self.refresh()
+
+
+class LeagueView(BaseView):
+    def compose(self) -> ComposeResult:
+        yield Static(id="league-table")
+        yield Static("Latest fixtures", classes="list-title")
+        yield ListView(id="fixtures-list")
+        with Horizontal():
+            yield Button("Higher division", id="prev-div", variant="primary")
+            yield Button("Lower division", id="next-div", variant="primary")
+
+    def refresh(self) -> None:
+        data = self.app.state.league_view()
+        table = Table(title=data["division"], expand=True)
+        table.add_column("Pos")
+        table.add_column("Team")
+        table.add_column("W")
+        table.add_column("D")
+        table.add_column("L")
+        table.add_column("GD")
+        table.add_column("Pts")
+
+        for row in data["table"]:
+            team_name = row["team"]
+            if row["highlight"]:
+                team_name = f"[bold]{team_name}[/bold]"
+            table.add_row(
+                table_position_to_str(row["position"]),
+                team_name,
+                str(row["wins"]),
+                str(row["draws"]),
+                str(row["losses"]),
+                str(row["goal_difference"]),
+                str(row["points"]),
+            )
+
+        self.query_one("#league-table", Static).update(table)
+
+        fixtures = self.query_one("#fixtures-list", ListView)
+        fixtures.clear()
+        for match in data["fixtures"]:
+            fixtures.append(ListItem(Static(f"{match['home']} {match['score']} {match['away']}")))
+
+        self.query_one("#prev-div", Button).disabled = not data["has_higher"]
+        self.query_one("#next-div", Button).disabled = not data["has_lower"]
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "prev-div":
+            self.app.state.change_division(-1)
+            self.refresh()
+        elif event.button.id == "next-div":
+            self.app.state.change_division(1)
+            self.refresh()
+

--- a/tui/screens/manager.py
+++ b/tui/screens/manager.py
@@ -1,0 +1,65 @@
+"""Manager statistics screen."""
+
+from __future__ import annotations
+
+from rich.table import Table
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Footer, Header, Static
+
+from .base import StateScreen
+
+
+class ManagerStatsScreen(StateScreen):
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="manager-layout"):
+            yield Static(id="manager-header")
+            yield Static(id="career-table")
+            yield Static(id="yearly-table")
+            yield Button("Return", id="close", variant="success")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        stats = self.app.state.manager_stats()
+        header = f"[bold]{stats['name']}[/bold] – Career points: {stats['points']}"
+        self.query_one("#manager-header", Static).update(header)
+
+        career = Table(title="Career totals", expand=True)
+        career.add_column("Stat")
+        career.add_column("Value")
+        for key in stats["career_order"]:
+            career.add_row(key, str(stats["career"][key]))
+        self.query_one("#career-table", Static).update(career)
+
+        yearly = Table(title="Season by season", expand=True)
+        yearly.add_column("Year")
+        yearly.add_column("Division")
+        yearly.add_column("Pos")
+        yearly.add_column("W")
+        yearly.add_column("D")
+        yearly.add_column("L")
+        yearly.add_column("GF")
+        yearly.add_column("GA")
+        yearly.add_column("Pts")
+        starting_year = self.app.state.game.year() if self.app.state.game else 0
+        for offset, season in enumerate(stats["yearly"]):
+            year = starting_year - offset
+            yearly.add_row(
+                str(year),
+                season.get("div", "-"),
+                str(season.get("pos", "-")),
+                str(season.get("Wins", "-")),
+                str(season.get("Draws", "-")),
+                str(season.get("Losses", "-")),
+                str(season.get("Goals For", "-")),
+                str(season.get("Goals Against", "-")),
+                str(season.get("pts", "-")),
+            )
+        self.query_one("#yearly-table", Static).update(yearly)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "close":
+            self.app.pop_screen()
+

--- a/tui/screens/match.py
+++ b/tui/screens/match.py
@@ -1,0 +1,210 @@
+"""Live match centre replicating the classic SimpleFM flow."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.reactive import reactive
+from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
+
+from ..state import PlayerSummary
+from .base import StateScreen
+
+
+class MatchPlayerList(ListView):
+    def set_players(self, players: List[PlayerSummary]) -> None:
+        self.clear()
+        for player in players:
+            info = f"{player.position} {player.name} ({player.age}) Skill {player.skill}"
+            if player.injured:
+                info += " [injured]"
+            item = ListItem(Static(info))
+            setattr(item, "player_id", player.identifier)
+            self.append(item)
+
+
+class MatchScreen(StateScreen):
+    auto_running = reactive(False)
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="match-layout"):
+            yield Static(id="scoreboard")
+            yield Static(id="possession")
+            with Horizontal(id="match-content"):
+                with Vertical():
+                    yield Static("Timeline", classes="list-title")
+                    yield ListView(id="timeline")
+                with Vertical(id="match-controls"):
+                    yield Button("Play minute", id="play", variant="success")
+                    yield Button("Auto-play", id="auto", variant="primary")
+                    yield Button("Finish match", id="finish", variant="warning")
+                    yield Button("Substitution", id="sub", variant="primary")
+                    yield Static(id="subs-left")
+                    yield Static(id="status-message")
+            with Horizontal(id="match-lists"):
+                with Vertical():
+                    yield Static("On the pitch", classes="list-title")
+                    yield MatchPlayerList(id="on-pitch")
+                with Vertical():
+                    yield Static("Bench", classes="list-title")
+                    yield MatchPlayerList(id="bench")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._auto_task = None
+        self._selection: List[Tuple[str, int]] = []
+        try:
+            self.app.state.begin_match()
+        except Exception as exc:
+            self.app.notify(str(exc), severity="error")
+            self.app.pop_screen()
+            return
+        self.refresh()
+
+    def on_unmount(self) -> None:
+        self._stop_auto()
+
+    def refresh(self) -> None:
+        try:
+            ctx = self.app.state.match_context()
+        except Exception as exc:
+            self.app.notify(str(exc), severity="error")
+            self.app.pop_screen()
+            return
+
+        scoreboard = (
+            f"{ctx['home']} {ctx['score'][0]} - {ctx['score'][1]} {ctx['away']}" +
+            f"    Minute: {ctx['minutes']}'"
+        )
+        self.query_one("#scoreboard", Static).update(scoreboard)
+
+        possession = (
+            f"Possession: {ctx['possession'][0]}% - {ctx['possession'][1]}%"
+            f"    Last 5': {ctx['last_five'][0]}% - {ctx['last_five'][1]}%"
+        )
+        self.query_one("#possession", Static).update(possession)
+
+        timeline = self.query_one("#timeline", ListView)
+        timeline.clear()
+        if ctx['goalscorers']:
+            for goal in ctx['goalscorers']:
+                timeline.append(ListItem(Static(f"{goal['minute']}' {goal['player']} ({goal['team']})")))
+        else:
+            timeline.append(ListItem(Static("No events yet."), disabled=True))
+
+        self.query_one("#on-pitch", MatchPlayerList).set_players(ctx['on_pitch'])
+        self.query_one("#bench", MatchPlayerList).set_players(ctx['bench'])
+
+        subs_left = f"Substitutions left: {ctx['subs_left']}"
+        if ctx['injured_player']:
+            subs_left += f"  |  Injured: {ctx['injured_player'].name}"
+        self.query_one("#subs-left", Static).update(subs_left)
+
+        status = "Match finished" if ctx['finished'] else ""
+        self.query_one("#status-message", Static).update(status)
+
+        self.query_one("#play", Button).disabled = ctx['finished']
+        self.query_one("#auto", Button).label = "Stop auto" if self.auto_running else "Auto-play"
+        self.query_one("#auto", Button).disabled = ctx['finished']
+        self.query_one("#sub", Button).disabled = not ctx['allow_substitution']
+        self.query_one("#finish", Button).label = "Continue" if ctx['finished'] else "Finish match"
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "play":
+            self._stop_auto()
+            self.app.state.play_minute()
+            self._after_tick()
+        elif event.button.id == "auto":
+            if self.auto_running:
+                self._stop_auto()
+            else:
+                self._start_auto()
+        elif event.button.id == "finish":
+            if self._is_match_finished():
+                self._complete_match()
+            else:
+                self.app.state.finish_match()
+                self._after_tick()
+        elif event.button.id == "sub":
+            self._prompt_substitution()
+
+    def _start_auto(self) -> None:
+        if not self.auto_running:
+            self.auto_running = True
+            self._auto_task = self.set_interval(0.5, self._auto_tick)
+
+    def _stop_auto(self) -> None:
+        if self.auto_running and self._auto_task:
+            self._auto_task.cancel()
+        self.auto_running = False
+        self._auto_task = None
+
+    def _auto_tick(self) -> None:
+        self.app.state.auto_play_tick()
+        self._after_tick()
+        if self._is_match_finished():
+            self._stop_auto()
+
+    def _after_tick(self) -> None:
+        self.refresh()
+        if self._is_match_finished() and not self.auto_running:
+            self.app.notify("Match finished", severity="information")
+
+    def _is_match_finished(self) -> bool:
+        try:
+            return self.app.state.match_context()["finished"]
+        except Exception:
+            return False
+
+    def _complete_match(self) -> None:
+        self._stop_auto()
+        summary = self.app.state.finalize_match()
+        self.app.show_summary(summary)
+        self.app.pop_screen()
+
+    def _prompt_substitution(self) -> None:
+        ctx = self.app.state.match_context()
+        if not ctx["allow_substitution"]:
+            self.app.notify("No substitutions left", severity="warning")
+            return
+        self._selection.clear()
+        self.app.notify("Select the player to replace and then the substitute", severity="information")
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        if event.list_view.id not in {"on-pitch", "bench"}:
+            return
+        player_id = getattr(event.item, "player_id", None)
+        if player_id is None:
+            return
+        self._selection.append((event.list_view.id, player_id))
+        if len(self._selection) == 2:
+            self._make_substitution()
+
+    def _make_substitution(self) -> None:
+        ctx = self.app.state.match_context()
+        injured = ctx["injured_player"]
+        on_pitch = next((pid for list_id, pid in self._selection if list_id == "on-pitch"), None)
+        bench = next((pid for list_id, pid in self._selection if list_id == "bench"), None)
+        self._selection.clear()
+
+        if bench is None:
+            self.app.notify("Choose a player from the bench", severity="warning")
+            return
+
+        if on_pitch is None:
+            if injured is not None:
+                on_pitch = injured.identifier
+            else:
+                self.app.notify("Choose a player on the pitch", severity="warning")
+                return
+
+        success = self.app.state.make_substitution(on_pitch, bench)
+        if not success:
+            self.app.notify("Substitution not allowed", severity="error")
+        else:
+            self.app.notify("Substitution made", severity="information")
+        self.refresh()
+

--- a/tui/screens/new_game.py
+++ b/tui/screens/new_game.py
@@ -1,0 +1,112 @@
+"""Screen for creating a new SimpleFM career."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from textual.app import ComposeResult
+from textual.containers import Grid, Vertical
+from textual.reactive import reactive
+from textual.widgets import Button, Footer, Header, Input, Select, Static
+
+from lib import constants
+
+from .base import StateScreen
+
+
+class NewGameScreen(StateScreen):
+    custom_enabled = reactive(False)
+
+    def compose(self) -> ComposeResult:
+        state = self.app.state
+
+        yield Header(show_clock=True)
+        with Vertical(id="form-layout"):
+            yield Static("[bold]Create a new career[/bold]", id="form-title")
+            yield Input(placeholder="Game name", id="game-name")
+            yield Input(placeholder="Manager name", id="manager-name")
+
+            team_options = [(team["name"], team["name"]) for team in state.list_selectable_teams()]
+            team_options.append(("Create custom club", "__custom__"))
+            yield Select(team_options, id="team-select", prompt="Choose team", value=team_options[0][1] if team_options else None)
+
+            with Grid(id="custom-section"):
+                yield Input(placeholder="Custom club name", id="custom-name")
+                yield Select([(c, c) for c in state.list_countries()], id="custom-country", prompt="Country")
+                yield Select([(c, c) for c in state.list_colors()], id="custom-color", prompt="Primary colour")
+
+                divisions = [(str(i), str(i)) for i in range(1, constants.COMPETITION["TOTAL_NUMBER_OF_DIVISIONS"] + 1)]
+                yield Select(divisions, id="custom-division", prompt="Starting division", value=divisions[0][1])
+
+                positions = [(str(i), str(i)) for i in range(1, constants.COMPETITION["TEAMS PER DIVISION"] + 1)]
+                yield Select(positions, id="custom-position", prompt="Previous season position", value=positions[0][1])
+
+            yield Button("Create game", id="create", variant="success")
+            yield Button("Back", id="back", variant="warning")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._update_custom_visibility()
+
+    def watch_custom_enabled(self, enabled: bool) -> None:
+        self._update_custom_visibility()
+
+    def _update_custom_visibility(self) -> None:
+        custom = self.query_one("#custom-section")
+        custom.display = "block" if self.custom_enabled else "none"
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "team-select":
+            self.custom_enabled = event.value == "__custom__"
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "create":
+            self._create_game()
+        elif event.button.id == "back":
+            self.app.pop_screen()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _create_game(self) -> None:
+        state = self.app.state
+
+        game_name = self.query_one("#game-name", Input).value.strip()
+        manager_name = self.query_one("#manager-name", Input).value.strip()
+        team_value = self.query_one("#team-select", Select).value
+
+        team_name: Optional[str] = None
+        custom: Optional[dict] = None
+
+        if team_value == "__custom__":
+            custom_name = self.query_one("#custom-name", Input).value.strip()
+            custom_country = self.query_one("#custom-country", Select).value
+            custom_color = self.query_one("#custom-color", Select).value
+            custom_division = self.query_one("#custom-division", Select).value
+            custom_position = self.query_one("#custom-position", Select).value
+
+            custom = {
+                "name": custom_name,
+                "country": custom_country,
+                "color": custom_color,
+                "prev_div": custom_division,
+                "prev_pos": custom_position,
+            }
+        else:
+            team_name = team_value
+
+        try:
+            state.start_new_game(
+                game_name=game_name,
+                manager_name=manager_name,
+                team_name=team_name,
+                custom_team=custom,
+            )
+        except Exception as exc:
+            self.app.notify(str(exc), severity="error")
+            return
+
+        self.app.notify("Career created", severity="information")
+        self.app.show_main()
+

--- a/tui/screens/start.py
+++ b/tui/screens/start.py
@@ -1,0 +1,35 @@
+"""Start screen with the retro banner and primary actions."""
+
+from __future__ import annotations
+
+from rich.panel import Panel
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Footer, Header, Static
+
+from .base import StateScreen
+
+ASCII_TITLE = """[bold #FCE300]╔═══════════════════════════════════════╗[/]
+[bold #FCE300]║[/]   [bold white]Simple Football Manager[/]   [bold #FCE300]║[/]
+[bold #FCE300]╚═══════════════════════════════════════╝[/]"""
+
+
+class StartScreen(StateScreen):
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Vertical(id="start-layout"):
+            yield Static(Panel.fit(ASCII_TITLE, border_style="#FCE300"), id="title")
+            yield Button("New Game", id="new-game", variant="success")
+            yield Button("Load Game", id="load-game", variant="primary")
+            yield Button("Quit", id="quit", variant="error")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "new-game":
+            self.app.show_new_game()
+        elif event.button.id == "load-game":
+            self.app.show_load_game()
+        elif event.button.id == "quit":
+            self.app.exit()
+

--- a/tui/screens/summary.py
+++ b/tui/screens/summary.py
@@ -1,0 +1,103 @@
+"""Weekly summary overlay shown after a match or simulation."""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.table import Table
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button, Footer, Header, ListItem, ListView, Static
+
+from .base import StateScreen
+
+
+class SummaryScreen(StateScreen):
+    def __init__(self, summary: dict) -> None:
+        super().__init__()
+        self.summary = summary
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="summary-layout"):
+            yield Static(id="match-summary")
+            yield Static(id="finance-summary")
+            yield Static("Training highlights", classes="list-title")
+            yield ListView(id="training-list")
+            yield Static("News", classes="list-title")
+            yield ListView(id="news-list")
+            yield Button("Return to dashboard", id="close", variant="success")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._render_match()
+        self._render_finances()
+        self._render_training()
+        self._render_news()
+
+    def _render_match(self) -> None:
+        match = self.summary.get("match")
+        if not match:
+            self.query_one("#match-summary", Static).update("[bold]No match played this week.[/bold]")
+            return
+        table = Table(title="Match result", expand=True)
+        table.add_column("Opponent")
+        table.add_column("Score")
+        table.add_column("Result")
+        table.add_row(match["opponent"], match["score"], match["result"])
+        if match["goals"]:
+            goals = Table(title="Goals", expand=True)
+            goals.add_column("Minute")
+            goals.add_column("Player")
+            goals.add_column("Team")
+            for goal in match["goals"]:
+                goals.add_row(str(goal["minute"]), goal["player"], goal["team"])
+            self.query_one("#match-summary", Static).update(Group(table, goals))
+        else:
+            self.query_one("#match-summary", Static).update(table)
+
+    def _render_finances(self) -> None:
+        finances = self.summary.get("finances", {})
+        table = Table(title="Finances", expand=True)
+        table.add_column("Category")
+        table.add_column("Weekly")
+        table.add_column("Season")
+        for key, values in finances.get("income", {}).items():
+            table.add_row(f"Income – {key}", values["weekly"], values["yearly"])
+        table.add_row("Income – Total", finances.get("income_total", ""), finances.get("income_total_yearly", ""))
+        for key, values in finances.get("expense", {}).items():
+            table.add_row(f"Expense – {key}", values["weekly"], values["yearly"])
+        table.add_row("Expense – Total", finances.get("expense_total", ""), finances.get("expense_total_yearly", ""))
+        table.add_row("Balance", finances.get("balance_weekly", ""), finances.get("balance_yearly", ""))
+        table.add_row("Cash", finances.get("cash", ""), "")
+        table.add_row("Season goal", str(finances.get("goal", "")), "")
+        table.add_row("Fan happiness", str(finances.get("fan_happiness", "")), "")
+        self.query_one("#finance-summary", Static).update(table)
+
+    def _render_training(self) -> None:
+        training = self.summary.get("training", [])
+        list_view = self.query_one("#training-list", ListView)
+        list_view.clear()
+        highlights = [entry for entry in training if entry.get("training")]
+        if not highlights:
+            list_view.append(ListItem(Static("No major training changes."), disabled=True))
+            return
+        for entry in highlights:
+            player = entry["player"]
+            change = entry.get("training", "")
+            list_view.append(ListItem(Static(f"{player.name} ({player.position}) {change}")))
+
+    def _render_news(self) -> None:
+        news = self.summary.get("news", [])
+        list_view = self.query_one("#news-list", ListView)
+        list_view.clear()
+        if not news:
+            list_view.append(ListItem(Static("No news this week."), disabled=True))
+            return
+        for item in news:
+            list_view.append(ListItem(Static(item)))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "close":
+            self.app.pop_screen()
+

--- a/tui/state.py
+++ b/tui/state.py
@@ -1,0 +1,609 @@
+"""Domain level state helpers backing the terminal UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import pickle
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from lib.Game import Game
+from lib.Match import Match
+from lib.Team import Team
+from lib.Player import Player
+from lib import constants, db, helpers as lib_helpers
+
+from . import formatters
+
+
+DEFAULT_SAVE_DIR = Path.home() / ".simplefm" / "games"
+
+
+@dataclass
+class PlayerSummary:
+    """Light-weight representation of a player for UI consumption."""
+
+    identifier: int
+    name: str
+    position: str
+    age: int
+    skill: int
+    status: int
+    country: Optional[str]
+    salary: int
+    contract: int
+    wanted_salary: Optional[int]
+    injured: bool
+    match_available: bool
+    weekly_training: float
+    skill_change: int
+    value: int
+
+    @classmethod
+    def from_player(cls, player: Player) -> "PlayerSummary":
+        return cls(
+            identifier=id(player),
+            name=player.name,
+            position=player.pos_to_str(),
+            age=player.age,
+            skill=int(player.skill),
+            status=player.playing_status,
+            country=getattr(player, "country", None),
+            salary=getattr(player, "salary", 0),
+            contract=getattr(player, "contract", 0),
+            wanted_salary=getattr(player, "wanted_salary", None),
+            injured=player.injured(),
+            match_available=player.match_available(),
+            weekly_training=getattr(player, "weekly_training", 0.0),
+            skill_change=getattr(player, "skill_change_last_week", 0),
+            value=getattr(player, "current_value", lambda: 0)(),
+        )
+
+
+def _group_players(players: Iterable[Player]) -> Dict[str, List[PlayerSummary]]:
+    groups: Dict[str, List[PlayerSummary]] = {
+        "starting": [],
+        "bench": [],
+        "reserves": [],
+    }
+    for player in players:
+        summary = PlayerSummary.from_player(player)
+        if player.playing_status == 0:
+            groups["starting"].append(summary)
+        elif player.playing_status == 1:
+            groups["bench"].append(summary)
+        else:
+            groups["reserves"].append(summary)
+    return groups
+
+
+def _match_team_index(match: Match, team: Team) -> int:
+    return 0 if match.teams[0] == team else 1
+
+
+class SimpleFMState:
+    """Container encapsulating the simulation state for the TUI."""
+
+    def __init__(self, save_dir: Optional[Path] = None) -> None:
+        self.saves_dir = Path(save_dir or DEFAULT_SAVE_DIR)
+        self.saves_dir.mkdir(parents=True, exist_ok=True)
+
+        self.game: Optional[Game] = None
+        self.active_team: Optional[Team] = None
+        self.current_match: Optional[Match] = None
+        self.auto_play: bool = False
+        self.last_summary: Optional[Dict[str, object]] = None
+        self.active_division_index: int = 0
+
+    # ------------------------------------------------------------------
+    # Game bootstrap / persistence
+    # ------------------------------------------------------------------
+
+    def list_saved_games(self) -> List[str]:
+        return sorted(p.stem for p in self.saves_dir.glob("*.sfm"))
+
+    def list_selectable_teams(self) -> List[Dict[str, str]]:
+        total = constants.COMPETITION["TEAMS PER DIVISION"] * constants.COMPETITION[
+            "TOTAL_NUMBER_OF_DIVISIONS"
+        ]
+        return db.TEAMS[:total]
+
+    def list_countries(self) -> List[str]:
+        return sorted(country["name"] for country in db.COUNTRIES)
+
+    def list_colors(self) -> List[str]:
+        return sorted(color["name"] for color in db.COLORS)
+
+    def start_new_game(
+        self,
+        *,
+        game_name: str,
+        manager_name: str,
+        team_name: Optional[str] = None,
+        custom_team: Optional[Dict[str, object]] = None,
+    ) -> Game:
+        if not game_name:
+            raise ValueError("Game name is required")
+        if not manager_name:
+            raise ValueError("Manager name is required")
+        if (self.saves_dir / f"{game_name}.sfm").exists():
+            raise ValueError("A save with that name already exists")
+
+        if team_name is None and custom_team is None:
+            raise ValueError("Either an existing team or custom team configuration is required")
+
+        game = Game(name=game_name)
+
+        if custom_team:
+            name = str(custom_team["name"])
+            if not name:
+                raise ValueError("Custom team name cannot be empty")
+            prev_div = int(custom_team["prev_div"])
+            prev_pos = int(custom_team["prev_pos"])
+            color = str(custom_team["color"])
+            country = str(custom_team["country"])
+        else:
+            name = str(team_name)
+            matches = [team for team in db.TEAMS if team["name"] == name]
+            if not matches:
+                raise ValueError("Selected team was not found")
+            template = matches[0]
+            color = template["color"]
+            country = template["country"]
+            prev_div = template.get("prev_div")
+            prev_pos = template.get("prev_pos")
+
+        manager = {"name": manager_name}
+        human_team = {
+            "name": name,
+            "color": color,
+            "country": country,
+            "prev_pos": prev_pos,
+            "prev_div": prev_div,
+        }
+
+        game.start(human_team=human_team, manager=manager)
+        game.start_of_season()
+
+        self.game = game
+        if not game.human_teams:
+            raise RuntimeError("Unable to locate the human controlled team")
+        self.active_team = game.human_teams[0]
+        self.active_division_index = game.divisions.index(self.active_team.division)
+        self.current_match = None
+        self.last_summary = None
+        return game
+
+    def load_game(self, name: str) -> Game:
+        path = self.saves_dir / f"{name}.sfm"
+        if not path.exists():
+            raise FileNotFoundError(path)
+
+        with path.open("rb") as fh:
+            data = pickle.load(fh)
+
+        game = Game()
+        game.__dict__.update(data)
+
+        self.game = game
+        if not game.human_teams:
+            raise RuntimeError("Save file does not contain a human controlled team")
+        self.active_team = game.human_teams[0]
+        self.active_division_index = game.divisions.index(self.active_team.division)
+        self.current_match = None
+        self.last_summary = None
+        return game
+
+    def save_game(self) -> None:
+        if not self.game:
+            raise RuntimeError("No active game to save")
+        self.game.save(str(self.saves_dir))
+
+    # ------------------------------------------------------------------
+    # UI helpers
+    # ------------------------------------------------------------------
+
+    def header_context(self) -> Dict[str, object]:
+        self._ensure_game()
+        assert self.game and self.active_team
+        return {
+            "game_name": self.game.name,
+            "team": self.active_team.name,
+            "manager": self.active_team.manager.name,
+            "season": self.game.season,
+            "week": self.game.week + 1,
+            "year": self.game.year(),
+            "money": formatters.money_to_str(self.active_team.money),
+            "fan_happiness": self.active_team.fan_happiness,
+        }
+
+    def team_overview(self) -> Dict[str, List[PlayerSummary]]:
+        self._ensure_game()
+        assert self.active_team
+        self.active_team.order_players_by_playing_status()
+        return _group_players(self.active_team.players)
+
+    def tactic_options(self) -> List[str]:
+        self._ensure_game()
+        assert self.active_team
+        options = [formatters.tactic_to_str(tac) for tac in self.active_team.list_of_allowed_tactics()]
+        options.append("Top skill")
+        return options
+
+    def set_tactic(self, tactic_label: str) -> None:
+        self._ensure_game()
+        assert self.active_team
+        if tactic_label == "Top skill":
+            self.active_team.set_playing_tactic()
+        else:
+            tactic = lib_helpers.str_to_tactic(tactic_label)
+            if tactic == "Top skill":
+                self.active_team.set_playing_tactic()
+            else:
+                self.active_team.set_playing_tactic(tactic)
+
+    def swap_players(self, player_out_id: int, player_in_id: int) -> bool:
+        self._ensure_game()
+        assert self.active_team
+        player_out = self._player_by_id(player_out_id)
+        player_in = self._player_by_id(player_in_id)
+        success = self.active_team.replace_player(player_in, player_out)
+        if success:
+            self.active_team.order_players_by_playing_status()
+        return success
+
+    def next_opponent(self) -> Optional[Dict[str, object]]:
+        self._ensure_game()
+        assert self.game and self.active_team
+        opponent = self.active_team.next_opponent(self.game.week)
+        if not opponent:
+            return None
+        return {
+            "name": opponent.name,
+            "avg_skill": int(round(opponent.avg_skill, 0)),
+            "tactic": formatters.tactic_to_str(opponent.tactic) if opponent.tactic else "?",
+            "location": self.active_team.next_match_to_str(self.game.week),
+        }
+
+    # ------------------------------------------------------------------
+    # Match handling
+    # ------------------------------------------------------------------
+
+    def begin_match(self) -> Match:
+        self._ensure_game()
+        assert self.game and self.active_team
+        if self.current_match and not self.current_match.finished:
+            return self.current_match
+        match = self.active_team.next_match(self.game.week)
+        if match is None:
+            raise RuntimeError("No scheduled match for this week")
+        self.current_match = match
+        self.auto_play = False
+        return match
+
+    def match_context(self) -> Dict[str, object]:
+        if not self.current_match:
+            raise RuntimeError("Match has not started")
+
+        match = self.current_match
+        assert self.active_team
+        team_index = _match_team_index(match, self.active_team)
+        opponent = match.teams[1 - team_index]
+        substitutions_left = 3 - match.substitutions[team_index]
+
+        return {
+            "minutes": match.minutes,
+            "score": tuple(match.score),
+            "home": match.teams[0].name,
+            "away": match.teams[1].name,
+            "is_home": team_index == 0,
+            "possession": match.ball_possession(),
+            "last_five": match.ball_possession_last_5_minutes(),
+            "goalscorers": [
+                {
+                    "minute": scorer["minute"],
+                    "name": scorer["player"].name,
+                    "team": scorer["team"].name,
+                }
+                for scorer in match.goalscorers
+            ],
+            "on_pitch": [PlayerSummary.from_player(p) for p in self.active_team.players if p.playing_status == 0],
+            "bench": [PlayerSummary.from_player(p) for p in self.active_team.players if p.playing_status == 1],
+            "subs_left": substitutions_left,
+            "allow_substitution": match.allow_substitution(self.active_team),
+            "injured_player": PlayerSummary.from_player(match.injured_player_out)
+            if match.injured_player_out
+            else None,
+            "finished": match.finished,
+            "opponent": opponent.name,
+        }
+
+    def play_minute(self) -> None:
+        if not self.current_match:
+            raise RuntimeError("Match has not started")
+        self.current_match.minute()
+
+    def auto_play_tick(self) -> None:
+        if not self.current_match:
+            raise RuntimeError("Match has not started")
+        self.auto_play = True
+        if not self.current_match.finished:
+            self.current_match.minute()
+        if self.current_match.finished:
+            self.auto_play = False
+
+    def finish_match(self) -> None:
+        if not self.current_match:
+            raise RuntimeError("Match has not started")
+        self.current_match.simulate(90)
+        self.auto_play = False
+
+    def make_substitution(self, player_out_id: int, player_in_id: int) -> bool:
+        if not self.current_match:
+            raise RuntimeError("Match has not started")
+        assert self.active_team
+        player_out = self._player_by_id(player_out_id)
+        player_in = self._player_by_id(player_in_id)
+        if not self.current_match.allow_substitution(self.active_team):
+            return False
+        success = self.active_team.replace_player(
+            player_in, player_out, in_match=True, match_minutes=self.current_match.minutes
+        )
+        if success:
+            self.current_match.substitution_made_by_team(self.active_team)
+        return success
+
+    def finalize_match(self) -> Dict[str, object]:
+        if not self.current_match:
+            raise RuntimeError("Match has not started")
+        summary = self._prepare_weekly_summary(self.current_match)
+        assert self.game
+        self.game.simulate_weekly_matches()
+        self.game.next_week()
+        self.last_summary = summary
+        self.current_match = None
+        return summary
+
+    # ------------------------------------------------------------------
+    # Training and transfers
+    # ------------------------------------------------------------------
+
+    def training_report(self) -> List[Dict[str, object]]:
+        self._ensure_game()
+        assert self.active_team
+        return [
+            {
+                "player": PlayerSummary.from_player(player),
+                "training": formatters.training_to_str(player.weekly_training),
+            }
+            for player in self.active_team.players
+        ]
+
+    def transfer_targets(self) -> List[PlayerSummary]:
+        self._ensure_game()
+        assert self.active_team
+        players = sorted(
+            self.active_team.players_to_buy,
+            key=lambda player: (-player.skill, player.current_value(), player.position),
+        )
+        return [PlayerSummary.from_player(player) for player in players]
+
+    def squad_for_transfers(self) -> List[PlayerSummary]:
+        self._ensure_game()
+        assert self.active_team
+        players = sorted(self.active_team.players, key=lambda p: (p.position, -p.current_value()))
+        return [PlayerSummary.from_player(player) for player in players]
+
+    def buy_player(self, player_id: int) -> bool:
+        self._ensure_game()
+        assert self.active_team
+        player = self._player_from_transfer_list(player_id)
+        if not player:
+            return False
+        if not self.active_team.has_place_to_buy_player():
+            raise ValueError("Squad already at maximum size")
+        if not self.active_team.has_money_to_buy_player(player):
+            raise ValueError("Insufficient funds")
+        self.active_team.buy_player(player)
+        return True
+
+    def sell_player(self, player_id: int) -> bool:
+        self._ensure_game()
+        assert self.active_team
+        player = self._player_by_id(player_id)
+        if not self.active_team.has_place_to_sell_player():
+            raise ValueError("You must keep at least 11 players")
+        if player.position == 0 and not self.active_team.has_at_least_one_gk():
+            raise ValueError("Selling would leave you without a goalkeeper")
+        if player.contract:
+            raise ValueError("Player already has a contract for the season")
+        if player.injured():
+            raise ValueError("Cannot sell an injured player")
+        self.active_team.sell_player(player)
+        return True
+
+    def renew_contract(self, player_id: int) -> bool:
+        self._ensure_game()
+        assert self.active_team
+        player = self._player_by_id(player_id)
+        if player.contract:
+            raise ValueError("Player already has a contract")
+        player.set_renew_contract_wanted_salary()
+        self.active_team.renew_contract(player)
+        return True
+
+    # ------------------------------------------------------------------
+    # Information and progression
+    # ------------------------------------------------------------------
+
+    def finances(self) -> Dict[str, object]:
+        self._ensure_game()
+        assert self.active_team
+        income_keys = {"Prize Money", "Sold Players", "Sponsors"}
+        expense_keys = {"Salaries", "Bought Players"}
+
+        def _totals(keys: Iterable[str]) -> Tuple[int, int]:
+            weekly = sum(self.active_team.weekly_finances[key] for key in keys)
+            yearly = sum(self.active_team.yearly_finances[key] for key in keys)
+            return weekly, yearly
+
+        weekly_income, yearly_income = _totals(income_keys)
+        weekly_expense, yearly_expense = _totals(expense_keys)
+
+        balance_weekly = weekly_income - weekly_expense
+        balance_yearly = yearly_income - yearly_expense
+
+        return {
+            "income": {
+                key: {
+                    "weekly": formatters.money_to_str(self.active_team.weekly_finances[key]),
+                    "yearly": formatters.money_to_str(self.active_team.yearly_finances[key]),
+                }
+                for key in income_keys
+            },
+            "expense": {
+                key: {
+                    "weekly": formatters.money_to_str(self.active_team.weekly_finances[key]),
+                    "yearly": formatters.money_to_str(self.active_team.yearly_finances[key]),
+                }
+                for key in expense_keys
+            },
+            "income_total": formatters.money_to_str(weekly_income),
+            "income_total_yearly": formatters.money_to_str(yearly_income),
+            "expense_total": formatters.money_to_str(weekly_expense),
+            "expense_total_yearly": formatters.money_to_str(yearly_expense),
+            "balance_weekly": formatters.money_to_str(balance_weekly),
+            "balance_yearly": formatters.money_to_str(balance_yearly),
+            "cash": formatters.money_to_str(self.active_team.money),
+            "goal": self.active_team.min_pos_per_season_points_per_week(),
+            "fan_happiness": self.active_team.fan_happiness,
+            "news": self.active_team.weekly_news.str_list(),
+        }
+
+    def continue_week(self) -> Dict[str, object]:
+        self._ensure_game()
+        assert self.game and self.active_team
+        match = self.active_team.next_match(self.game.week)
+        summary = self._prepare_weekly_summary(match)
+        self.game.simulate_weekly_matches()
+        self.game.next_week()
+        self.last_summary = summary
+        return summary
+
+    def league_view(self) -> Dict[str, object]:
+        self._ensure_game()
+        assert self.game
+        division = self.game.divisions[self.active_division_index]
+        division.order_table_by_position()
+        table = [
+            {
+                "position": index + 1,
+                "team": team.name,
+                "wins": team.league_stats["Wins"],
+                "draws": team.league_stats["Draws"],
+                "losses": team.league_stats["Losses"],
+                "goal_difference": team.goal_difference(),
+                "points": team.league_points(),
+                "highlight": getattr(self.active_team, "name", None) == team.name,
+            }
+            for index, team in enumerate(division.teams)
+        ]
+
+        week_index = max(0, min(self.game.week - 1, len(division.matches) - 1))
+        fixtures = [
+            {
+                "home": match.teams[0].name,
+                "away": match.teams[1].name,
+                "score": f"{match.score[0]}-{match.score[1]}" if match.finished else "vs",
+            }
+            for match in division.matches[week_index]
+        ]
+
+        total_playable = len(self.game.divisions) - 1
+        return {
+            "division": division.name,
+            "table": table,
+            "fixtures": fixtures,
+            "has_lower": self.active_division_index < total_playable - 1,
+            "has_higher": self.active_division_index > 0,
+        }
+
+    def change_division(self, direction: int) -> None:
+        self._ensure_game()
+        assert self.game
+        new_index = self.active_division_index + direction
+        new_index = max(0, min(new_index, len(self.game.divisions) - 2))
+        self.active_division_index = new_index
+
+    def manager_stats(self) -> Dict[str, object]:
+        self._ensure_game()
+        assert self.active_team
+        manager = self.active_team.manager
+        manager.update_stats()
+        career_stats = manager.career_stats()
+        return {
+            "name": manager.name,
+            "points": manager.points(),
+            "career": career_stats,
+            "career_order": manager.career_stats_order(),
+            "yearly": list(reversed(manager.yearly_stats)),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_game(self) -> None:
+        if not self.game or not self.active_team:
+            raise RuntimeError("No active game")
+
+    def _player_by_id(self, player_id: int) -> Player:
+        assert self.active_team
+        for player in self.active_team.players:
+            if id(player) == int(player_id):
+                return player
+        raise ValueError(f"Unknown player id {player_id}")
+
+    def _player_from_transfer_list(self, player_id: int) -> Optional[Player]:
+        assert self.active_team
+        for player in self.active_team.players_to_buy:
+            if id(player) == int(player_id):
+                return player
+        return None
+
+    def _prepare_weekly_summary(self, match: Optional[Match]) -> Dict[str, object]:
+        self._ensure_game()
+        assert self.active_team
+        if match is None:
+            match = self.active_team.next_match(self.game.week) if self.game else None
+
+        match_summary = None
+        if match:
+            team_index = _match_team_index(match, self.active_team)
+            opponent = match.teams[1 - team_index]
+            result = "Draw"
+            if match.score[team_index] > match.score[1 - team_index]:
+                result = "Win"
+            elif match.score[team_index] < match.score[1 - team_index]:
+                result = "Loss"
+            match_summary = {
+                "opponent": opponent.name,
+                "score": f"{match.score[team_index]}-{match.score[1 - team_index]}",
+                "result": result,
+                "goals": [
+                    {
+                        "minute": goal["minute"],
+                        "player": goal["player"].name,
+                        "team": goal["team"].name,
+                    }
+                    for goal in match.goalscorers
+                ],
+            }
+
+        return {
+            "match": match_summary,
+            "finances": self.finances(),
+            "training": self.training_report(),
+            "news": self.active_team.weekly_news.str_list(),
+        }
+

--- a/tui/styles.css
+++ b/tui/styles.css
@@ -1,0 +1,93 @@
+Screen {
+    background: #0b1523;
+    color: #fce300;
+}
+
+#start-layout {
+    align: center middle;
+    padding: 2 4;
+    border: tall #fce300;
+    background: #10243b;
+    gap: 1;
+    width: 60%;
+}
+
+#title {
+    align: center middle;
+    padding: 1 0;
+}
+
+Button {
+    background: #133c55;
+    border: tall #fce300;
+    text-style: bold;
+}
+
+Button.-success {
+    background: #1f6f50;
+}
+
+Button.-warning {
+    background: #7f5400;
+}
+
+Button.-error {
+    background: #8c1c13;
+}
+
+#form-layout,
+#load-layout,
+#manager-layout,
+#summary-layout,
+#match-layout,
+#main-layout {
+    padding: 1 2;
+    gap: 1;
+}
+
+#main-layout #content,
+#match-layout,
+#manager-layout,
+#summary-layout,
+#form-layout,
+#load-layout {
+    border: tall #fce300;
+    background: #10243b;
+}
+
+#nav Button {
+    width: 1fr;
+    margin: 0 1;
+}
+
+.list-title {
+    text-style: bold;
+    color: #f9f871;
+}
+
+ListView {
+    height: 1fr;
+    border: round #fce300;
+    background: #0d1b2a;
+}
+
+#team-lists,
+#match-lists,
+#transfers-layout {
+    gap: 2;
+}
+
+#match-controls {
+    gap: 1;
+    width: 24;
+}
+
+#manager-header,
+#game-header,
+#scoreboard,
+#possession,
+#finance-summary,
+#match-summary {
+    text-style: bold;
+}
+


### PR DESCRIPTION
## Summary
- Created a retro-styled terminal interface with Textual that mirrors the original menus, match centre, and manager views so players can manage their club without the graphical client.
- Added a dedicated state layer that adapts the existing simulation code for terminal widgets, keeping the business rules intact while presenting tidy data to the new screens.
- Wrote regression tests for the state layer to confirm tactics, transfers, and week progression continue to behave as expected.

## Testing
- python -m unittest tests.test_tui_state

## Out of Scope
- The existing Kivy and web front-ends were left untouched; improving or replacing those experiences will come later if needed.

------
https://chatgpt.com/codex/tasks/task_e_68e0e832d85483309fe03e59312d8eb3